### PR TITLE
Try 2 with SustainManager

### DIFF
--- a/About/About.xml
+++ b/About/About.xml
@@ -44,4 +44,12 @@
     Video Review:
     Thank you BaRKy for reviewing my mod! I am honored! (https://www.youtube.com/watch?v=EWudgTJksMU)
   </description>
+  <modDependencies>
+    <li>
+        <packageId>brrainz.harmony</packageId>
+        <displayName>Harmony</displayName>
+        <steamWorkshopUrl>steam://url/CommunityFilePage/2009463077</steamWorkshopUrl>
+        <downloadUrl>https://github.com/pardeike/HarmonyRimWorld/releases/latest</downloadUrl>
+    </li>
+  </modDependencies>
 </ModMetaData>

--- a/Source/AmbientSoundManager_Patch.cs
+++ b/Source/AmbientSoundManager_Patch.cs
@@ -1,0 +1,45 @@
+﻿using RimWorld;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Verse;
+using Verse.Sound;
+
+namespace RimThreaded
+{
+    class AmbientSoundManager_Patch
+    {
+        static readonly PropertyInfo altitudeWindSoundCreatedPI = typeof(AmbientSoundManager).GetProperty("AltitudeWindSoundCreated", BindingFlags.NonPublic | BindingFlags.Static);
+        static readonly FieldInfo biomeAmbientSustainersFI = typeof(AmbientSoundManager).GetField("biomeAmbientSustainers", BindingFlags.Static | BindingFlags.NonPublic);
+        public static bool RecreateMapSustainers()
+        {
+            if (!(bool)altitudeWindSoundCreatedPI.GetValue(null))
+            {
+                SoundDefOf.Ambient_AltitudeWind.TrySpawnSustainer(SoundInfo.OnCamera(MaintenanceType.None));
+            }
+
+            List<Sustainer> sustainers = (biomeAmbientSustainersFI.GetValue(null) as List<Sustainer>);
+            foreach (Sustainer s in sustainers)
+            {
+                if (SustainerManager_Patch.allSustainers.ContainsKey(s) && !s.Ended)
+                {
+                    s.End();
+                }
+            }
+            sustainers.Clear();
+            if (Find.CurrentMap != null)
+            {
+                List<SoundDef> soundsAmbient = Find.CurrentMap.Biome.soundsAmbient;
+                for (int j = 0; j < soundsAmbient.Count; j++)
+                {
+                    Sustainer item = soundsAmbient[j].TrySpawnSustainer(SoundInfo.OnCamera(MaintenanceType.None));
+                    if (!SustainerManager_Patch.allSustainers.TryAdd(item, item))
+                    {
+                        item.End();
+                    }
+                }
+            }
+            return false;
+        }
+    }
+}

--- a/Source/RimThreaded.cs
+++ b/Source/RimThreaded.cs
@@ -320,9 +320,12 @@ namespace RimThreaded
 			Prefix(original, patched, "RegisterSustainer");
 			Prefix(original, patched, "DeregisterSustainer");
 			Prefix(original, patched, "SustainerExists");
-			Prefix(original, patched, "SustainerManagerUpdate");
-			Prefix(original, patched, "UpdateAllSustainerScopes");
 			Prefix(original, patched, "EndAllInMap");
+
+			//RecreateMapSustainers
+			original = typeof(AmbientSoundManager);
+			patched = typeof(AmbientSoundManager_Patch);
+			Prefix(original, patched, "RecreateMapSustainers");
 
 			//SubSustainer
 			original = typeof(SubSustainer);

--- a/Source/SustainerManager.cs
+++ b/Source/SustainerManager.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using Verse;
 using Verse.Sound;
 
@@ -8,29 +9,28 @@ namespace RimThreaded
 {
     public class SustainerManager_Patch
     {
-        public static ConcurrentDictionary<Sustainer, Sustainer> allSustainersDict = new ConcurrentDictionary<Sustainer, Sustainer>();
-        public static ConcurrentStack<List<Sustainer>> sListStack = new ConcurrentStack<List<Sustainer>>();
+        public static ConcurrentDictionary<Sustainer, Sustainer> allSustainers = new ConcurrentDictionary<Sustainer, Sustainer>();
 
         public static bool get_AllSustainers(SustainerManager __instance, ref List<Sustainer> __result)
         {
-            __result = allSustainersDict.Values.ToList();
+            __result = allSustainers.Values.ToList();
             return false;
         }
 
         public static bool RegisterSustainer(SustainerManager __instance, Sustainer newSustainer)
         {
-            allSustainersDict.TryAdd(newSustainer, newSustainer);
+            allSustainers.TryAdd(newSustainer, newSustainer);
             return false;
         }
 
         public static bool DeregisterSustainer(SustainerManager __instance, Sustainer oldSustainer)
         {
-            allSustainersDict.TryRemove(oldSustainer, out _);
+            allSustainers.TryRemove(oldSustainer, out _);
             return false;
         }
         public static bool SustainerExists(SustainerManager __instance, ref bool __result, SoundDef def)
         {
-            foreach (var kv in allSustainersDict)
+            foreach (var kv in allSustainers)
             {
                 if (kv.Value.def == def)
                 {
@@ -42,74 +42,26 @@ namespace RimThreaded
             return false;
         }
 
-        public static bool SustainerManagerUpdate(SustainerManager __instance)
+        private readonly static FieldInfo playingPerDefFI = typeof(SustainerManager).GetField("playingPerDef", BindingFlags.Static | BindingFlags.NonPublic);
+        public static void SustainerManagerUpdate(SustainerManager __instance)
         {
-            foreach (var kv in allSustainersDict)
+            // SustainerManagerUpdate is executed prior to Ticks so this will only ever be run on a single thread.
+            Dictionary<SoundDef, List<Sustainer>> d = playingPerDefFI.GetValue(__instance) as Dictionary<SoundDef, List<Sustainer>>;
+            d.Clear();
+            foreach (var kv in allSustainers)
             {
-                kv.Value.SustainerUpdate();
+                if (!d.TryGetValue(kv.Value.def, out List<Sustainer> l))
+                {
+                    l = new List<Sustainer>();
+                    d[kv.Value.def] = l;
+                }
+                l.Add(kv.Value);
             }
-            __instance.UpdateAllSustainerScopes();
-            return false;
         }
 
-        public static bool UpdateAllSustainerScopes(SustainerManager __instance)
-        {            
-            Dictionary<SoundDef, List<Sustainer>> playingPerDef = new Dictionary<SoundDef, List<Sustainer>>();
-            foreach (var kv in allSustainersDict)
-            {
-                Sustainer allSustainer = kv.Value;
-                if (!playingPerDef.ContainsKey(allSustainer.def))
-                {
-                    if (!sListStack.TryPop(out List<Sustainer> sustainerList))
-                        sustainerList = new List<Sustainer>();
-                    sustainerList.Add(allSustainer);
-                    playingPerDef.Add(allSustainer.def, sustainerList);
-                }
-                else
-                    playingPerDef[allSustainer.def].Add(allSustainer);
-            }
-            foreach (KeyValuePair<SoundDef, List<Sustainer>> keyValuePair in playingPerDef)
-            {
-                SoundDef key = keyValuePair.Key;
-                List<Sustainer> sustainerList = keyValuePair.Value;
-                if (sustainerList.Count - key.maxVoices < 0)
-                {
-                    for (int index = 0; index < sustainerList.Count; ++index)
-                        sustainerList[index].scopeFader.inScope = true;
-                }
-                else
-                {
-                    for (int index = 0; index < sustainerList.Count; ++index)
-                        sustainerList[index].scopeFader.inScope = false;
-                    sustainerList.Sort((a, b) => a.CameraDistanceSquared.CompareTo(b.CameraDistanceSquared));
-                    int num = 0;
-                    for (int index = 0; index < sustainerList.Count; ++index)
-                    {
-                        sustainerList[index].scopeFader.inScope = true;
-                        ++num;
-                        if (num >= key.maxVoices)
-                            break;
-                    }
-                    for (int index = 0; index < sustainerList.Count; ++index)
-                    {
-                        if (!sustainerList[index].scopeFader.inScope)
-                            sustainerList[index].scopeFader.inScopePercent = 0.0f;
-                    }
-                }
-            }
-            foreach (KeyValuePair<SoundDef, List<Sustainer>> keyValuePair in playingPerDef)
-            {
-                keyValuePair.Value.Clear();
-                //SimplePool<List<Sustainer>>.Return(keyValuePair.Value);
-                sListStack.Push(keyValuePair.Value);
-            }
-            //playingPerDef().Clear();
-            
-            return false;
-        }
         public static bool EndAllInMap(SustainerManager __instance, Map map)
         {
-            foreach (var kv in allSustainersDict)
+            foreach (var kv in allSustainers)
             {
                 if (kv.Value.info.Maker.Map == map)
                     kv.Value.End();


### PR DESCRIPTION
Allowing the base game's code to take over for updates as it's known to run as a single thread once all workers are done.
Adding AmbientSoundManager_Patch to interface directly with the SustainManager_Patch's dict