### PR TITLE
Fix Stack Empty Exception

### DIFF
--- a/Source/Rand.cs
+++ b/Source/Rand.cs
@@ -111,6 +111,10 @@ namespace RimThreaded
             ulong result2;
             lock (stateStack2)
             {
+                if (stateStack2.Count == 0)
+                {
+                    PushState();
+                }
                 result2 = stateStack2.Pop();
             }
             seed2 = (uint)(result2 & (ulong) uint.MaxValue);


### PR DESCRIPTION
```c#
[MapReroll][ERR] Exception during preview generation: System.InvalidOperationException: Stack empty.
  at System.Collections.Generic.Stack`1[T].Pop () [0x00008] in <ae22a4e8f83c41d69684ae7f557133d9>:0 
  at RimThreaded.Rand_Patch.PopState () [0x00013] in <42e2629b2dfc42bb98acc27fea75687f>:0 
  at (wrapper dynamic-method) Verse.Rand.Verse.Rand.PopState_Patch1()
  at MapReroll.MapPreviewGenerator.GenerateMapGrids (System.Int32 mapTile, System.Int32 mapSize, System.Boolean revealCaves) [0x000db] in <7b42efcedff04411902136cc66c68b91>:0 
  at MapReroll.MapPreviewGenerator.GeneratePreviewForSeed (System.String seed, System.Int32 mapTile, System.Int32 mapSize, System.Boolean revealCaves, MapReroll.MapPreviewGenerator+ThreadableTexture texture) [0x00046] in <7b42efcedff04411902136cc66c68b91>:0 
Verse.Log:Error(String, Boolean)
HugsLib.Utils.ModLogger:ReportException(Exception, String, Boolean, String)
MapReroll.MapPreviewGenerator:GeneratePreviewForSeed(String, Int32, Int32, Boolean, ThreadableTexture)
MapReroll.MapPreviewGenerator:DoThreadWork()
System.Threading.ThreadHelper:ThreadStart_Context(Object)
System.Threading.ExecutionContext:RunInternal(ExecutionContext, ContextCallback, Object, Boolean)
System.Threading.ExecutionContext:Run(ExecutionContext, ContextCallback, Object, Boolean)
System.Threading.ExecutionContext:Run(ExecutionContext, ContextCallback, Object)
System.Threading.ThreadHelper:ThreadStart()
```