### PR TITLE
Fixed CTD from unity call in Android Tiers

### DIFF
--- a/Source/GeneratePawns_Patch.cs
+++ b/Source/GeneratePawns_Patch.cs
@@ -11,7 +11,7 @@ using Verse;
 
 namespace RimThreaded
 {
-    class GeneratePawns_Patch_Transpile
+    public class GeneratePawns_Patch_Transpile
     {
         public static IEnumerable<CodeInstruction> Listener(IEnumerable<CodeInstruction> instructions, ILGenerator iLGenerator)
         {
@@ -58,7 +58,6 @@ namespace RimThreaded
                     m.GetParameters()[0].ParameterType == typeof(String)
                 );
 
-            Log.Message(i.Name + " <" + i.GetGenericArguments()[0].FullName + "> (" + i.GetParameters()[0] + ")");
 
             return i.MakeGenericMethod(typeof(Texture2D));
         }

--- a/Source/GeneratePawns_Patch.cs
+++ b/Source/GeneratePawns_Patch.cs
@@ -1,0 +1,66 @@
+﻿using HarmonyLib;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Reflection.Emit;
+using System.Text;
+using System.Threading.Tasks;
+using UnityEngine;
+using Verse;
+
+namespace RimThreaded
+{
+    class GeneratePawns_Patch_Transpile
+    {
+        public static IEnumerable<CodeInstruction> Listener(IEnumerable<CodeInstruction> instructions, ILGenerator iLGenerator)
+        {
+            List<CodeInstruction> l = instructions.ToList();
+            bool match = false;
+
+                
+            //Replacement Instructions
+            CodeInstruction loadToken = new CodeInstruction(OpCodes.Ldtoken, typeof(Texture2D).GetTypeInfo());
+            CodeInstruction resolveToken = new CodeInstruction(OpCodes.Call, typeof(Type).GetMethod("GetTypeFromHandle"));
+
+
+            for (int x = 0; x < l.Count; x++)
+            {
+                CodeInstruction i = l[x];
+
+                if (i.opcode == OpCodes.Call
+                    && (MethodInfo)i.operand == TargetMethodHelper())
+                {
+                    match = true;
+
+                    i.operand = typeof(Resources_Patch).GetMethod("Load");
+
+                    l.Insert(x, resolveToken);
+                    l.Insert(x, loadToken);
+                    
+
+                }
+                yield return l[x];
+            }
+            if (!match)
+            {
+                Log.Error("No IL Instruction found for PawnGroupMakerUtility_Patch.");
+            }
+        }
+
+        public static MethodBase TargetMethodHelper()
+        {
+            MethodInfo i = typeof(Resources).GetMethods().Single(
+                m =>
+                    m.Name == "Load" &&
+                    m.GetGenericArguments().Length == 1 &&
+                    m.GetParameters().Length == 1 &&
+                    m.GetParameters()[0].ParameterType == typeof(String)
+                );
+
+            Log.Message(i.Name + " <" + i.GetGenericArguments()[0].FullName + "> (" + i.GetParameters()[0] + ")");
+
+            return i.MakeGenericMethod(typeof(Texture2D));
+        }
+    }
+}

--- a/Source/Resources.cs
+++ b/Source/Resources.cs
@@ -1,0 +1,38 @@
+﻿using HarmonyLib;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using UnityEngine;
+using Verse;
+
+namespace RimThreaded
+{
+    class Resources_Patch
+    {
+        public static Func<object[], UnityEngine.Object> safeFunction = p => Resources.Load((string)p[0], (Type)p[1]);
+
+        public static UnityEngine.Object Load(string path, Type type)
+        {
+            int tID = Thread.CurrentThread.ManagedThreadId;
+            if (RimThreaded.mainRequestWaits.TryGetValue(tID, out EventWaitHandle eventWaitStart))
+            {
+                object[] functionAndParameters = new object[] { safeFunction, new object[] { path, type } };
+                lock (RimThreaded.safeFunctionRequests)
+                {
+                    RimThreaded.safeFunctionRequests[tID] = functionAndParameters;
+                }
+                RimThreaded.mainThreadWaitHandle.Set();
+                eventWaitStart.WaitOne();
+                RimThreaded.safeFunctionResults.TryGetValue(tID, out object safeFunctionResult);
+                return (UnityEngine.Object) safeFunctionResult;
+            }
+            Log.Error("Could not load Resource of type " + type.ToString() + " at path " + path);
+            return null;
+        }
+    }
+
+}

--- a/Source/RimThreadedHarmony.cs
+++ b/Source/RimThreadedHarmony.cs
@@ -45,7 +45,10 @@ namespace RimThreaded
 		public static Type combatExtendedVerb_MeleeAttackCE;
 		public static Type dubsSkylight_Patch_GetRoof;
 		public static Type jobsOfOpportunityJobsOfOpportunity_Hauling;
+		public static Type androidTiers_GeneratePawns_Patch;
 		public static FieldInfo cachedStoreCell;
+		
+
 		public static List<CodeInstruction> EnterLock(LocalBuilder lockObject, LocalBuilder lockTaken, List<CodeInstruction> loadLockObjectInstructions, List<CodeInstruction> instructionsList, ref int currentInstructionIndex)
 		{
 			List<CodeInstruction> codeInstructions = new List<CodeInstruction>();
@@ -1461,10 +1464,20 @@ namespace RimThreaded
 
 			//Building_Trap
 			original = typeof(Building_Trap);
-			patched = typeof(Building_Trap_Patch);
+			//patched = typeof(Building_Trap_Patch);
 			//Prefix(original, patched, "Tick");
 			patched = typeof(Building_Trap_Transpile);
 			Transpile(original, patched, "Tick");
+
+
+			// Resources_Patch
+			/* Doesn't work as Load is an external method (without a method body) and can therefor not be prefixed. Transpile would maybe be possible, but I dont think, it's a good idea...
+			 * Changed method call to a rimthreaded specific one instead. See Resources_Patch::Load
+			original = typeof(Resources);
+			patched = typeof(Resources_Patch);
+			Prefix(original, patched, "Load", new Type[] { typeof(string), typeof(Type) });
+			*/
+
 
 			//MOD COMPATIBILITY
 
@@ -1486,7 +1499,7 @@ namespace RimThreaded
 			combatExtendedVerb_MeleeAttackCE = AccessTools.TypeByName("CombatExtended.Verb_MeleeAttackCE");
 			dubsSkylight_Patch_GetRoof = AccessTools.TypeByName("Dubs_Skylight.Patch_GetRoof");
 			jobsOfOpportunityJobsOfOpportunity_Hauling = AccessTools.TypeByName("JobsOfOpportunity.JobsOfOpportunity+Hauling");
-
+			androidTiers_GeneratePawns_Patch = AccessTools.TypeByName("MOARANDROIDS.PawnGroupMakerUtility_Patch").GetNestedType("GeneratePawns_Patch");
 
 			if (giddyUpCoreUtilitiesTextureUtility != null)
 			{
@@ -1608,6 +1621,16 @@ namespace RimThreaded
 				//methodName = "TryHaul";
 				//Log.Message("RimThreaded is patching " + jobsOfOpportunityJobsOfOpportunity_Hauling.FullName + " " + methodName);
 				//Transpile(jobsOfOpportunityJobsOfOpportunity_Hauling, patched, methodName);
+			}
+
+			if (androidTiers_GeneratePawns_Patch != null)
+            {
+				string methodName = "Listener";
+				patched = typeof(GeneratePawns_Patch_Transpile);
+				Log.Message("RimThreaded is patching " + androidTiers_GeneratePawns_Patch.FullName + " " + methodName);
+				Log.Message("Utility_Patch::Listener != null: " + (AccessTools.Method(androidTiers_GeneratePawns_Patch, "Listener") != null));
+				Log.Message("Utility_Patch_Transpile::Listener != null: " + (AccessTools.Method(patched, "Listener") != null));
+				Transpile(androidTiers_GeneratePawns_Patch, patched, methodName);
 			}
 
 			Log.Message("RimThreaded patching is complete.");


### PR DESCRIPTION
Fixed CTD from unity-call Resources.Load with Android Tiers.

Replaced call to Resources.Load<Texture2D>(String path) with a safe imlementation in Resources_Patch.

