### PR TITLE
Update issue templates (fixed labels / tags)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report_0high.md
+++ b/.github/ISSUE_TEMPLATE/bug_report_0high.md
@@ -1,8 +1,9 @@
 ---
 name: Reproducible Vanilla Bug Report (High Priority)
-about: Submit a bug report that occurs in RimWorld running only RimThreaded and DLCs that can be reproduced fairly consistantly
+about: Submit a bug report that occurs in RimWorld running only RimThreaded and DLCs
+  that can be reproduced fairly consistantly
 title: ''
-labels: bug, reproducible, vanilla
+labels: Bug, Reproducible, Vanilla RT
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/bug_report_0high.md
+++ b/.github/ISSUE_TEMPLATE/bug_report_0high.md
@@ -1,7 +1,6 @@
 ---
 name: Reproducible Vanilla Bug Report (High Priority)
-about: Submit a bug report that occurs in RimWorld running only RimThreaded and DLCs
-  that can be reproduced fairly consistantly
+about: Submit a bug report that occurs in RimWorld running only RimThreaded and DLCs that can be reproduced fairly consistantly
 title: ''
 labels: Bug, Reproducible, Vanilla RT
 assignees: ''

--- a/.github/ISSUE_TEMPLATE/bug_report_1med.md
+++ b/.github/ISSUE_TEMPLATE/bug_report_1med.md
@@ -1,8 +1,9 @@
 ---
 name: Reproducible Non-Vanilla Bug Report (Medium Priority)
-about: Submit a bug report that occurs in modded RimWorld that can be reproduced fairly consistantly
+about: Submit a bug report that occurs in modded RimWorld that can be reproduced fairly
+  consistantly
 title: ''
-labels: bug, reproducible
+labels: Bug, Reproducible
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/bug_report_1med.md
+++ b/.github/ISSUE_TEMPLATE/bug_report_1med.md
@@ -1,7 +1,6 @@
 ---
 name: Reproducible Non-Vanilla Bug Report (Medium Priority)
-about: Submit a bug report that occurs in modded RimWorld that can be reproduced fairly
-  consistantly
+about: Submit a bug report that occurs in modded RimWorld that can be reproduced fairly consistantly
 title: ''
 labels: Bug, Reproducible
 assignees: ''

--- a/.github/ISSUE_TEMPLATE/bug_report_2low.md
+++ b/.github/ISSUE_TEMPLATE/bug_report_2low.md
@@ -1,7 +1,6 @@
 ---
 name: Non-Reproducible Vanilla Bug Report (Low Priority)
-about: Submit a bug report that occurs in RimWorld running only RimThreaded and DLCs
-  that cannot be reproduced fairly consistantly
+about: Submit a bug report that occurs in RimWorld running only RimThreaded and DLCs that cannot be reproduced fairly consistantly
 title: ''
 labels: Bug, Vanilla RT
 assignees: ''

--- a/.github/ISSUE_TEMPLATE/bug_report_2low.md
+++ b/.github/ISSUE_TEMPLATE/bug_report_2low.md
@@ -1,8 +1,9 @@
 ---
 name: Non-Reproducible Vanilla Bug Report (Low Priority)
-about: Submit a bug report that occurs in RimWorld running only RimThreaded and DLCs that cannot be reproduced fairly consistantly
+about: Submit a bug report that occurs in RimWorld running only RimThreaded and DLCs
+  that cannot be reproduced fairly consistantly
 title: ''
-labels: bug, vanilla
+labels: Bug, Vanilla RT
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/bug_report_3lowest.md
+++ b/.github/ISSUE_TEMPLATE/bug_report_3lowest.md
@@ -1,8 +1,9 @@
 ---
 name: Non-Reproducible Non-Vanilla Bug Report (Lowest Priority)
-about: Submit a bug report that occurs in modded RimWorld that cannot be reproduced fairly consistantly
+about: Submit a bug report that occurs in modded RimWorld that cannot be reproduced
+  fairly consistantly
 title: ''
-labels: bug
+labels: Bug
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/bug_report_3lowest.md
+++ b/.github/ISSUE_TEMPLATE/bug_report_3lowest.md
@@ -1,7 +1,6 @@
 ---
 name: Non-Reproducible Non-Vanilla Bug Report (Lowest Priority)
-about: Submit a bug report that occurs in modded RimWorld that cannot be reproduced
-  fairly consistantly
+about: Submit a bug report that occurs in modded RimWorld that cannot be reproduced fairly consistantly
 title: ''
 labels: Bug
 assignees: ''


### PR DESCRIPTION
Due to editing of the tags the issue templates didn't add them automatically anymore, now they should be fine.