### PR TITLE
CacheMissingPartsCommonAncestors transpiler

### DIFF
--- a/Source/HediffSet.cs
+++ b/Source/HediffSet.cs
@@ -20,18 +20,6 @@ namespace RimThreaded
         public static AccessTools.FieldRef<HediffSet, Queue<BodyPartRecord>> missingPartsCommonAncestorsQueue =
             AccessTools.FieldRefAccess<HediffSet, Queue<BodyPartRecord>>("missingPartsCommonAncestorsQueue");
 
-        public static object rebuildCacheMissingPartsCommonAncestors = new object();
-
-        public static bool CacheMissingPartsCommonAncestorsPrefix(HediffSet __instance)
-        {
-            Monitor.Enter(rebuildCacheMissingPartsCommonAncestors);
-            return true;
-        }
-        public static void CacheMissingPartsCommonAncestorsPostfix(HediffSet __instance)
-        {
-            Monitor.Exit(rebuildCacheMissingPartsCommonAncestors);
-        }
-
 
         public static bool HasImmunizableNotImmuneHediff(HediffSet __instance, ref bool __result)
         {

--- a/Source/HediffSet_Transpile.cs
+++ b/Source/HediffSet_Transpile.cs
@@ -1,4 +1,4 @@
-﻿using HarmonyLib;
+using HarmonyLib;
 using System.Collections.Generic;
 using System.Linq;
 using Verse;
@@ -180,29 +180,129 @@ namespace RimThreaded
             }
         }
 
-        
-        public static IEnumerable<CodeInstruction> CacheMissingPartsCommonAncestors(IEnumerable<CodeInstruction> instructions, ILGenerator iLGenerator)
+
+        public static IEnumerable<CodeInstruction> CacheMissingPartsCommonAncestors ( IEnumerable<CodeInstruction> instructions, ILGenerator iLGenerator )
         {
             List<CodeInstruction> instructionsList = instructions.ToList();
-            int i = 0;
-            List<CodeInstruction> loadLockObjectInstructions = new List<CodeInstruction>
-            {
-                new CodeInstruction(OpCodes.Ldarg_0)
-            };
-            LocalBuilder lockObject = iLGenerator.DeclareLocal(typeof(object));
-            LocalBuilder lockTaken = iLGenerator.DeclareLocal(typeof(bool));
-            foreach (CodeInstruction ci in EnterLock(
-                lockObject, lockTaken, loadLockObjectInstructions, instructionsList, ref i))
-                yield return ci;
-            while (i < instructionsList.Count - 1)
-            {
-                yield return instructionsList[i++];
-            }
-            foreach (CodeInstruction ci in ExitLock(
-                iLGenerator, lockObject, lockTaken, instructionsList, ref i))
-                yield return ci;
-            yield return instructionsList[i++];
-        }
 
+            LocalBuilder newCachedMPCA = iLGenerator.DeclareLocal( typeof( List<Hediff_MissingPart> ) );
+            LocalBuilder lockObject = iLGenerator.DeclareLocal( typeof( Queue<BodyPartRecord> ) );
+            LocalBuilder lockTaken = iLGenerator.DeclareLocal( typeof( bool ) );
+
+            List<CodeInstruction> MPCAQueue = new List<CodeInstruction>
+            {
+                new CodeInstruction(OpCodes.Ldarg_0),
+                new CodeInstruction(OpCodes.Ldfld, Field(typeof(HediffSet), "missingPartsCommonAncestorsQueue"))
+            };
+
+            List<CodeInstruction> cachedMPCA = new List<CodeInstruction>
+            {
+                new CodeInstruction(OpCodes.Ldarg_0),
+                new CodeInstruction(OpCodes.Ldfld, Field(typeof(HediffSet), "cachedMissingPartsCommonAncestors"))
+            };
+
+
+            // find first instruction after if-else and remove code before it
+            int i = 0;
+            while ( i < instructionsList.Count && !IsCodeInstructionsMatching( MPCAQueue, instructionsList, i ) )
+            {
+                i++;
+            }
+            instructionsList.RemoveRange( 0, i );
+
+            // init local variable newCachedMPCA
+            instructionsList.InsertRange( 0, new CodeInstruction[]
+            {
+                new CodeInstruction( OpCodes.Newobj, Constructor( typeof( List<Hediff_MissingPart> ) ) ),
+                new CodeInstruction( OpCodes.Stloc, newCachedMPCA.LocalIndex )
+            } );
+
+            // replace remaining this.cachedMissingPartsCommonAncestors references with newCachedMPCA
+            i = 0;
+            while ( i < instructionsList.Count )
+            {
+                if ( IsCodeInstructionsMatching( cachedMPCA, instructionsList, i ) )
+                {
+                    instructionsList[i] = new CodeInstruction( OpCodes.Ldloc, newCachedMPCA.LocalIndex );
+                    instructionsList.RemoveRange( i + 1, cachedMPCA.Count - 1 );
+                }
+                i++;
+            }
+
+            // set cachedMissingPartsCommonAncestors at the end
+            instructionsList.InsertRange( instructionsList.Count - 1, new CodeInstruction[]
+            {
+                new CodeInstruction(OpCodes.Ldarg_0),
+                new CodeInstruction(OpCodes.Ldloc, newCachedMPCA.LocalIndex),
+                new CodeInstruction(OpCodes.Stfld, Field(typeof(HediffSet), "cachedMissingPartsCommonAncestors") )
+            } );
+
+            // enter lock
+            i = 0;
+            instructionsList.InsertRange( i, EnterLock( lockObject, lockTaken, MPCAQueue, instructionsList, ref i ) );
+
+            // exit lock
+            i = instructionsList.Count - 1;
+            instructionsList.InsertRange( i, ExitLock( iLGenerator, lockObject, lockTaken, instructionsList, ref i ) );
+
+            // Log.Message( string.Join( "\n", instructionsList.Select( ( ci, l ) => l + " " + ci ) ) );
+
+            return instructionsList;
+        }
+        // equivalent change:
+        /*
+        private void CacheMissingPartsCommonAncestors()
+        {
+            lock(this.missingPartsCommonAncestorsQueue)
+            {
+                var cmpca = new List<Hediff_MissingPart>();
+
+                // ------- REMOVE FROM HERE
+	            if (this.cachedMissingPartsCommonAncestors == null)
+	            {
+		            this.cachedMissingPartsCommonAncestors = new List<Hediff_MissingPart>();
+	            }
+	            else
+	            {
+		            this.cachedMissingPartsCommonAncestors.Clear();
+	            }
+                // ------- REMOVE TO HERE
+                // ============ SAME
+	            this.missingPartsCommonAncestorsQueue.Clear();
+	            this.missingPartsCommonAncestorsQueue.Enqueue(this.pawn.def.race.body.corePart);
+	            while (this.missingPartsCommonAncestorsQueue.Count != 0)
+	            {
+		            BodyPartRecord node = this.missingPartsCommonAncestorsQueue.Dequeue();
+		            if (!this.PartOrAnyAncestorHasDirectlyAddedParts(node))
+		            {
+			            Hediff_MissingPart hediffMissingPart = (from x in this.GetHediffs<Hediff_MissingPart>()
+			            where x.Part == node
+			            select x).FirstOrDefault<Hediff_MissingPart>();
+			            if (hediffMissingPart != null)
+			            {
+                            // ***** replace *********************
+				            this.cachedMissingPartsCommonAncestors  .Add(hediffMissingPart);
+                            // *****  with   *********************
+                            cmpca                                   .Add(hediffMissingPart);
+                            // ***********************************
+                            
+			            }
+			            else
+			            {
+				            for (int index = 0; index < node.parts.Count; index++)
+				            {
+					            this.missingPartsCommonAncestorsQueue.Enqueue(node.parts[index]);
+				            }
+			            }
+		            }
+	            }
+                // ============ SAME
+
+                this.cachedMissingPartsCommonAncestors = cmpca;
+            }
+
+        }
+         
+         */
     }
 }


### PR DESCRIPTION
Thought about it a bit more, and came up with this, should prevent any race conditions from happening when using HediffSet.CacheMissingPartsCommonAncestors and HediffSet.GetMissingPartsCommonAncestors.