### PR TITLE
More settings, safety patch.

### DIFF
--- a/Source/AlertsReadout.cs
+++ b/Source/AlertsReadout.cs
@@ -36,10 +36,10 @@ namespace RimThreaded
                 return false;
             }
 
-            if (TickManager_Patch.curTimeSpeed(Find.TickManager) != TimeSpeed.Ultrafast)
+            if (TickManager_Patch.curTimeSpeed(Find.TickManager) == TimeSpeed.Ultrafast && RimThreadedMod.Settings.disablesomealets)
             {
-                //Uncommenting this will disable alert checks on ultrafast speed for an added speed boost
-                //return false;
+                //this will disable alert checks on ultrafast speed for an added speed boost
+                return false; 
             }
 
             curAlertIndex(__instance)++;

--- a/Source/RimThreaded.cs
+++ b/Source/RimThreaded.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Verse;
@@ -17,9 +17,8 @@ namespace RimThreaded
     {
         public static DateTime lastClosestThingGlobal = DateTime.Now;
 
-        public static int maxThreads = Math.Max(int.Parse(RimThreadedMod.Settings.maxThreadsBuffer), 1);
-        public static int timeoutMS = Math.Max(int.Parse(RimThreadedMod.Settings.timeoutMSBuffer), 5000);
-        public static bool suppressTexture2dError = RimThreadedMod.Settings.suppressTexture2dError;
+        public static int maxThreads = Math.Min(Math.Max(int.Parse(RimThreadedMod.Settings.maxThreadsBuffer), 1), 128);
+        public static int timeoutMS = Math.Min(Math.Max(int.Parse(RimThreadedMod.Settings.timeoutMSBuffer), 5000), 100000);
         public static float timeSpeedNormal = float.Parse(RimThreadedMod.Settings.timeSpeedNormalBuffer);
         public static float timeSpeedFast = float.Parse(RimThreadedMod.Settings.timeSpeedFastBuffer);
         public static float timeSpeedSuperfast = float.Parse(RimThreadedMod.Settings.timeSpeedSuperfastBuffer);

--- a/Source/RimThreadedMod.cs
+++ b/Source/RimThreadedMod.cs
@@ -1,4 +1,4 @@
-﻿using HarmonyLib;
+using HarmonyLib;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -13,99 +13,99 @@ using Verse.Sound;
 using RimWorld.Planet;
 using System.IO;
 
-namespace RimThreaded
-{
-	class RimThreadedMod : Mod
-	{
-		public static RimThreadedSettings Settings;
-		public RimThreadedMod(ModContentPack content) : base(content)
-		{
-			Settings = GetSettings<RimThreadedSettings>();
-		}
-		public override void DoSettingsWindowContents(Rect inRect)
-		{
-			if (Settings.modsText.Length == 0)
-			{
-				Settings.modsText = "Potential RimThreaded mod conflicts :\n";
-				Settings.modsText += getPotentialModConflicts();
-				
-				//string path = "hmodText.txt";
-				//StreamWriter writer = new StreamWriter(path, true);
-				//writer.WriteLine(Settings.modsText);
-				//writer.Close();
-			}
-			Settings.DoWindowContents(inRect);
-			if (Settings.maxThreads != RimThreaded.maxThreads)
-			{
-				RimThreaded.maxThreads = Math.Max(Settings.maxThreads, 1);
-				RimThreaded.RestartAllWorkerThreads();
-			}
-			RimThreaded.timeoutMS = Math.Max(Settings.timeoutMS, 1);
-			RimThreaded.timeSpeedNormal = Settings.timeSpeedNormal;
-			RimThreaded.timeSpeedFast = Settings.timeSpeedFast;
-			RimThreaded.timeSpeedSuperfast = Settings.timeSpeedSuperfast;
-			RimThreaded.timeSpeedUltrafast = Settings.timeSpeedUltrafast;
+namespace RimThreaded 
+{ 
+    class RimThreadedMod : Mod
+    {
+        public static RimThreadedSettings Settings;
+        public RimThreadedMod(ModContentPack content) : base(content)
+        {
+            Settings = GetSettings<RimThreadedSettings>();
+        }
+        public override void DoSettingsWindowContents(Rect inRect)
+        {
+            if (Settings.modsText.Length == 0)
+            {
+                Settings.modsText = "Potential RimThreaded mod conflicts :\n";
+                Settings.modsText += getPotentialModConflicts();
 
-		}
+                //string path = "hmodText.txt";
+                //StreamWriter writer = new StreamWriter(path, true);
+                //writer.WriteLine(Settings.modsText);
+                //writer.Close();
+            }
+            Settings.DoWindowContents(inRect);
+            if (Settings.maxThreads != RimThreaded.maxThreads)
+            {
+                RimThreaded.maxThreads = RimThreadedMod.Settings.disablelimits ? Math.Max(Settings.maxThreads, 1) : Math.Min(Math.Max(Settings.maxThreads, 1), 128);
+                RimThreaded.RestartAllWorkerThreads();
+            }
+            RimThreaded.timeoutMS = RimThreadedMod.Settings.disablelimits ? Math.Max(Settings.timeoutMS, 1) : Math.Min(Math.Max(Settings.timeoutMS, 5000), 100000);
+            RimThreaded.timeSpeedNormal = Settings.timeSpeedNormal;
+            RimThreaded.timeSpeedFast = Settings.timeSpeedFast;
+            RimThreaded.timeSpeedSuperfast = Settings.timeSpeedSuperfast;
+            RimThreaded.timeSpeedUltrafast = Settings.timeSpeedUltrafast;
+
+        }
 
         public static string getPotentialModConflicts()
         {
-			string modsText = "";
-			IEnumerable<MethodBase> originalMethods = Harmony.GetAllPatchedMethods();
-			foreach (MethodBase originalMethod in originalMethods)
-			{
-				Patches patches = Harmony.GetPatchInfo(originalMethod);
-				if (patches is null) { }
-				else
-				{
-					bool isRimThreadedPrefixed = false;
-					foreach (Patch patch in patches.Prefixes)
-					{
+            string modsText = "";
+            IEnumerable<MethodBase> originalMethods = Harmony.GetAllPatchedMethods();
+            foreach (MethodBase originalMethod in originalMethods)
+            {
+                Patches patches = Harmony.GetPatchInfo(originalMethod);
+                if (patches is null) { }
+                else
+                {
+                    bool isRimThreadedPrefixed = false;
+                    foreach (Patch patch in patches.Prefixes)
+                    {
 
-						if (patch.owner.Equals("majorhoff.rimthreaded") && !RimThreadedHarmony.nonDestructivePrefixes.Contains(patch.PatchMethod) && (patches.Prefixes.Count > 1 || patches.Postfixes.Count > 0 || patches.Transpilers.Count > 0))
-						{
-							isRimThreadedPrefixed = true;
-							modsText += "\n  ---Patch method: " + patch.PatchMethod.DeclaringType.FullName + " " + patch.PatchMethod + "---\n";
-							modsText += "  RimThreaded priority: " + patch.priority + "\n";
-							break;
-						}
-					}
-					if (isRimThreadedPrefixed)
-					{
-						foreach (Patch patch in patches.Prefixes)
-						{
-							if (!patch.owner.Equals("majorhoff.rimthreaded"))
-							{
-								//Settings.modsText += "method: " + patch.PatchMethod + " - ";
-								modsText += "  owner: " + patch.owner + " - ";
-								modsText += "  priority: " + patch.priority + "\n";
-							}
-						}
-						foreach (Patch patch in patches.Postfixes)
-						{
-							//Settings.modsText += "method: " + patch.PatchMethod + " - ";
-							modsText += "  owner: " + patch.owner + " - ";
-							modsText += "  priority: " + patch.priority + "\n";
-						}
-						foreach (Patch patch in patches.Transpilers)
-						{
-							//Settings.modsText += "method: " + patch.PatchMethod + " - ";
-							modsText += "  owner: " + patch.owner + " - ";
-							modsText += "  priority: " + patch.priority + "\n";
-						}
-					}
-				}
-			}
-			return modsText;
-		}
+                        if (patch.owner.Equals("majorhoff.rimthreaded") && !RimThreadedHarmony.nonDestructivePrefixes.Contains(patch.PatchMethod) && (patches.Prefixes.Count > 1 || patches.Postfixes.Count > 0 || patches.Transpilers.Count > 0))
+                        {
+                            isRimThreadedPrefixed = true;
+                            modsText += "\n  ---Patch method: " + patch.PatchMethod.DeclaringType.FullName + " " + patch.PatchMethod + "---\n";
+                            modsText += "  RimThreaded priority: " + patch.priority + "\n";
+                            break;
+                        }
+                    }
+                    if (isRimThreadedPrefixed)
+                    {
+                        foreach (Patch patch in patches.Prefixes)
+                        {
+                            if (!patch.owner.Equals("majorhoff.rimthreaded"))
+                            {
+                                //Settings.modsText += "method: " + patch.PatchMethod + " - ";
+                                modsText += "  owner: " + patch.owner + " - ";
+                                modsText += "  priority: " + patch.priority + "\n";
+                            }
+                        }
+                        foreach (Patch patch in patches.Postfixes)
+                        {
+                            //Settings.modsText += "method: " + patch.PatchMethod + " - ";
+                            modsText += "  owner: " + patch.owner + " - ";
+                            modsText += "  priority: " + patch.priority + "\n";
+                        }
+                        foreach (Patch patch in patches.Transpilers)
+                        {
+                            //Settings.modsText += "method: " + patch.PatchMethod + " - ";
+                            modsText += "  owner: " + patch.owner + " - ";
+                            modsText += "  priority: " + patch.priority + "\n";
+                        }
+                    }
+                }
+            }
+            return modsText;
+        }
 
         public override string SettingsCategory()
-		{
-			return "RimThreaded";
+        {
+            return "RimThreaded";
 
-		}
+        }
 
-	}
-	
+    }
+
 }
 

--- a/Source/RimThreadedSettings.cs
+++ b/Source/RimThreadedSettings.cs
@@ -1,59 +1,77 @@
-﻿using Verse;
+using System;
+using Verse;
 using UnityEngine;
 
 namespace RimThreaded
 {
-	public class RimThreadedSettings : ModSettings
-	{
-		public int maxThreads = 8;
-		public string maxThreadsBuffer = "8";
-		public int timeoutMS = 5000;
-		public string timeoutMSBuffer = "5000";
-		public float timeSpeedNormal = 1f;
-		public string timeSpeedNormalBuffer = "1";
-		public float timeSpeedFast = 3f;
-		public string timeSpeedFastBuffer = "3";
-		public float timeSpeedSuperfast = 12f;
-		public string timeSpeedSuperfastBuffer = "12";
-		public float timeSpeedUltrafast = 150f;
-		public string timeSpeedUltrafastBuffer = "150";
-		public bool suppressTexture2dError = true;
-		public string modsText = "";
+    public class RimThreadedSettings : ModSettings
+    {
+        public int maxThreads = 8;
+        public string maxThreadsBuffer = "8";
+        public int timeoutMS = 8000;
+        public string timeoutMSBuffer = "8000";
+        public float timeSpeedNormal = 1f;
+        public string timeSpeedNormalBuffer = "1";
+        public float timeSpeedFast = 3f;
+        public string timeSpeedFastBuffer = "3";
+        public float timeSpeedSuperfast = 12f;
+        public string timeSpeedSuperfastBuffer = "12";
+        public float timeSpeedUltrafast = 150f;
+        public string timeSpeedUltrafastBuffer = "150";
+        public bool disablesomealets = false;
+        public bool disablelimits = false;
+        public float scrollViewHeight;
+        public Vector2 scrollPosition;
+        public string modsText = "";
+        private string Threads;
 
-
-		public Vector2 scrollPos = new Vector2(0, 0);
-		public override void ExposeData()
-		{
-			base.ExposeData();
-			Scribe_Values.Look(ref maxThreadsBuffer, "maxThreadsBuffer", "8");
-			Scribe_Values.Look(ref timeoutMSBuffer, "timeoutMSBuffer", "5000");
-			Scribe_Values.Look(ref timeSpeedNormalBuffer, "timeSpeedNormalBuffer", "1");
-			Scribe_Values.Look(ref timeSpeedFastBuffer, "timeSpeedFastBuffer", "3");
-			Scribe_Values.Look(ref timeSpeedSuperfastBuffer, "timeSpeedSuperfastBuffer", "12");
-			Scribe_Values.Look(ref timeSpeedUltrafastBuffer, "timeSpeedUltrafastBuffer", "150");
-			Scribe_Values.Look(ref suppressTexture2dError, "suppressTexture2dError", true);
-		}
-
-		public void DoWindowContents(Rect inRect)
+        public Vector2 scrollPos = new Vector2(0, 0);
+        public override void ExposeData()
         {
-			Listing_Standard listing_Standard = new Listing_Standard();
-			listing_Standard.Begin(inRect);
-			Widgets.Label(listing_Standard.GetRect(30f), "Total worker threads (recommendation 1-2 per CPU core):");
-			Widgets.IntEntry(listing_Standard.GetRect(40f), ref maxThreads, ref maxThreadsBuffer);
-			Widgets.Label(listing_Standard.GetRect(30f), "Timeout (in miliseconds) waiting for threads (default: 5000):");
-			Widgets.IntEntry(listing_Standard.GetRect(40f), ref timeoutMS, ref timeoutMSBuffer, 100);
-			Widgets.Label(listing_Standard.GetRect(30f), "Timespeed Normal (multiply by 60 for Max TPS):");
-			Widgets.TextFieldNumeric(listing_Standard.GetRect(30f), ref timeSpeedNormal, ref timeSpeedNormalBuffer);
-			Widgets.Label(listing_Standard.GetRect(30f), "Timespeed Fast (multiply by 60 for Max TPS):");
-			Widgets.TextFieldNumeric(listing_Standard.GetRect(30f), ref timeSpeedFast, ref timeSpeedFastBuffer);
-			Widgets.Label(listing_Standard.GetRect(30f), "Timespeed Superfast (multiply by 60 for Max TPS):");
-			Widgets.TextFieldNumeric(listing_Standard.GetRect(30f), ref timeSpeedSuperfast, ref timeSpeedSuperfastBuffer);
-			Widgets.Label(listing_Standard.GetRect(30f), "Timespeed Ultrafast (multiply by 60 for Max TPS):");
-			Widgets.TextFieldNumeric(listing_Standard.GetRect(30f), ref timeSpeedUltrafast, ref timeSpeedUltrafastBuffer);
-			Widgets.CheckboxLabeled(listing_Standard.GetRect(40f), "Suppress 'Could not load UnityEngine.Texture2D' error:", ref suppressTexture2dError);
-			Widgets.TextAreaScrollable(listing_Standard.GetRect(150f), modsText, ref scrollPos);
-			listing_Standard.End();
-		}
-	}	
+
+            try
+            {
+                Threads = SystemInfo.processorCount.ToString();
+            }
+            catch (Exception)
+            {
+                Threads = "8";
+            }
+            base.ExposeData();
+            Scribe_Values.Look(ref maxThreadsBuffer, "maxThreadsBuffer", Threads);
+            Scribe_Values.Look(ref timeoutMSBuffer, "timeoutMSBuffer", "8000");
+            Scribe_Values.Look(ref timeSpeedNormalBuffer, "timeSpeedNormalBuffer", "1");
+            Scribe_Values.Look(ref timeSpeedFastBuffer, "timeSpeedFastBuffer", "3");
+            Scribe_Values.Look(ref timeSpeedSuperfastBuffer, "timeSpeedSuperfastBuffer", "12");
+            Scribe_Values.Look(ref timeSpeedUltrafastBuffer, "timeSpeedUltrafastBuffer", "150");
+            Scribe_Values.Look(ref disablesomealets, "disablesomealets", false);
+            Scribe_Values.Look(ref disablelimits, "disablelimits", false);
+
+        }
+
+        public void DoWindowContents(Rect inRect)
+        {
+            Listing_Standard listing_Standard = new Listing_Standard();
+            Rect viewRect = new Rect(0f, 0f, inRect.width - 16f, scrollViewHeight);
+            listing_Standard.BeginScrollView(inRect, ref scrollPosition, ref viewRect);
+            Widgets.Label(listing_Standard.GetRect(25f), "Total worker threads (recommendation 1-2 per CPU core):");
+            Widgets.IntEntry(listing_Standard.GetRect(37f), ref maxThreads, ref maxThreadsBuffer);
+            Widgets.Label(listing_Standard.GetRect(25f), "Timeout (in miliseconds) waiting for threads (default: 8000):");
+            Widgets.IntEntry(listing_Standard.GetRect(37f), ref timeoutMS, ref timeoutMSBuffer, 100);
+            Widgets.Label(listing_Standard.GetRect(25f), "Timespeed Normal (multiply by 60 for Max TPS):");
+            Widgets.TextFieldNumeric(listing_Standard.GetRect(30f), ref timeSpeedNormal, ref timeSpeedNormalBuffer);
+            Widgets.Label(listing_Standard.GetRect(25f), "Timespeed Fast (multiply by 60 for Max TPS):");
+            Widgets.TextFieldNumeric(listing_Standard.GetRect(30f), ref timeSpeedFast, ref timeSpeedFastBuffer);
+            Widgets.Label(listing_Standard.GetRect(25f), "Timespeed Superfast (multiply by 60 for Max TPS):");
+            Widgets.TextFieldNumeric(listing_Standard.GetRect(30f), ref timeSpeedSuperfast, ref timeSpeedSuperfastBuffer);
+            Widgets.Label(listing_Standard.GetRect(25f), "Timespeed Ultrafast (multiply by 60 for Max TPS):");
+            Widgets.TextFieldNumeric(listing_Standard.GetRect(30f), ref timeSpeedUltrafast, ref timeSpeedUltrafastBuffer);
+            Widgets.CheckboxLabeled(listing_Standard.GetRect(27f), "Disable alert updates at 4x speed:", ref disablesomealets);
+            Widgets.CheckboxLabeled(listing_Standard.GetRect(27f), "Disable thread/worker limit (debugging):", ref disablelimits);
+            Widgets.TextAreaScrollable(listing_Standard.GetRect(300f), modsText, ref scrollPos);
+            listing_Standard.EndScrollView(ref viewRect);
+            scrollViewHeight = viewRect.height;
+        }
+    }
 }
 

--- a/Source/RimThreadedSettings.cs
+++ b/Source/RimThreadedSettings.cs
@@ -20,6 +20,7 @@ namespace RimThreaded
         public string timeSpeedUltrafastBuffer = "150";
         public bool disablesomealets = false;
         public bool disablelimits = false;
+        public bool disableforcedslowdowns = false;
         public float scrollViewHeight;
         public Vector2 scrollPosition;
         public string modsText = "";
@@ -46,6 +47,7 @@ namespace RimThreaded
             Scribe_Values.Look(ref timeSpeedUltrafastBuffer, "timeSpeedUltrafastBuffer", "150");
             Scribe_Values.Look(ref disablesomealets, "disablesomealets", false);
             Scribe_Values.Look(ref disablelimits, "disablelimits", false);
+            Scribe_Values.Look(ref disableforcedslowdowns, "disableforcedslowdowns", false);
 
         }
 
@@ -68,6 +70,7 @@ namespace RimThreaded
             Widgets.TextFieldNumeric(listing_Standard.GetRect(30f), ref timeSpeedUltrafast, ref timeSpeedUltrafastBuffer);
             Widgets.CheckboxLabeled(listing_Standard.GetRect(27f), "Disable alert updates at 4x speed:", ref disablesomealets);
             Widgets.CheckboxLabeled(listing_Standard.GetRect(27f), "Disable thread/worker limit (debugging):", ref disablelimits);
+            Widgets.CheckboxLabeled(listing_Standard.GetRect(27f), "Disable slowdown on combat:", ref disableforcedslowdowns);
             Widgets.TextAreaScrollable(listing_Standard.GetRect(300f), modsText, ref scrollPos);
             listing_Standard.EndScrollView(ref viewRect);
             scrollViewHeight = viewRect.height;

--- a/Source/TickManager.cs
+++ b/Source/TickManager.cs
@@ -1,4 +1,4 @@
-﻿using HarmonyLib;
+using HarmonyLib;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -70,7 +70,7 @@ namespace RimThreaded
             else
             {
                 TimeControls_Patch.lastTickForcedSlow = false;
-                TimeControls_Patch.overrideForcedSlow = false;
+                if (!RimThreadedMod.Settings.disableforcedslowdowns) TimeControls_Patch.overrideForcedSlow = false;
             }
             
             switch (curTimeSpeed(__instance))

--- a/Source/TickManager.cs
+++ b/Source/TickManager.cs
@@ -58,7 +58,7 @@ namespace RimThreaded
 
         public static bool get_TickRateMultiplier(TickManager __instance, ref float __result)
         {
-            if (__instance.slower.ForcedNormalSpeed)
+            if (__instance.slower.ForcedNormalSpeed && !RimThreadedMod.Settings.disableforcedslowdowns)
             {
                 TimeControls_Patch.lastTickForcedSlow = true;
                 if (!TimeControls_Patch.overrideForcedSlow)
@@ -70,7 +70,7 @@ namespace RimThreaded
             else
             {
                 TimeControls_Patch.lastTickForcedSlow = false;
-                if (!RimThreadedMod.Settings.disableforcedslowdowns) TimeControls_Patch.overrideForcedSlow = false;
+                TimeControls_Patch.overrideForcedSlow = false;
             }
             
             switch (curTimeSpeed(__instance))

--- a/Source/TimeControls.cs
+++ b/Source/TimeControls.cs
@@ -231,7 +231,7 @@ namespace RimThreaded
                 rect.x += rect.width;
             }
 
-            if (Find.TickManager.slower.ForcedNormalSpeed)
+            if (Find.TickManager.slower.ForcedNormalSpeed && !RimThreadedMod.Settings.disableforcedslowdowns)
             {
                 Widgets.DrawLineHorizontal(rect.width * 2f, rect.height / 2f, rect.width * 2f);
             }


### PR DESCRIPTION
Removes suppressTexture2dError (Not used)
Set max threads to 128, setting it too high reduces peformance, setting it way too high crashes the game/unity.
Set max timeout to 100 seconds (can be disabled in settings)
Set standard timeout to 8000 (from 5000) certan raids and events late game will require this. (reports from users)
Set standard threads to the amount of threads a users cpu has (Core count will have been better but hard to program)
Add setting to ignore timeout and thread limit intreduced here and in 1.3.2
Add setting to disable alert updates at 4x speed (was already in the code, just enabled it)
Add setting to disable all slowdowns on combat.


Restructured settings page, added scrollbar, room for expanding in the feature.

indent was wrong in 2 files compared to rest of the project,
