### PR TITLE
Warn when running incompatible mods.

### DIFF
--- a/Source/AlertsReadout.cs
+++ b/Source/AlertsReadout.cs
@@ -1,11 +1,7 @@
-﻿using RimWorld;
+using RimWorld;
 using RimWorld.Planet;
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Reflection;
-using System.Text;
-using System.Threading.Tasks;
 using UnityEngine;
 using Verse;
 using static HarmonyLib.AccessTools;
@@ -22,9 +18,15 @@ namespace RimThreaded
             FieldRefAccess<AlertsReadout, List<Alert>>("AllAlerts");
         public static FieldRef<AlertsReadout, int> mouseoverAlertIndex =
             FieldRefAccess<AlertsReadout, int>("mouseoverAlertIndex");
+        private static bool runonce = true;
 
         public static bool AlertsReadoutUpdate(AlertsReadout __instance)
         {
+            if (runonce && RimThreadedMod.Settings.showModConflictsAlert)
+            {
+                RimThreadedMod.getPotentialModConflicts_2(); //Not sure where to put this, making it run on the main menu without black screen will have been perfect.
+                runonce = false;
+            }
             if (Mathf.Max(Find.TickManager.TicksGame, Find.TutorialState.endTick) < 600)
             {
                 return false;

--- a/Source/RimThreadedMod.cs
+++ b/Source/RimThreadedMod.cs
@@ -106,18 +106,18 @@ namespace RimThreaded
                 WrongLoadOrder = true;
                 ModConflictsMessage = NewLine + "Critical incompatibility:" + "\n" + NewLine + "RimThreaded is NOT last in your mod load order, fix immediately." + "\n";
             }
-            ModConflictsMessage = ModConflictsMessage + NewLine + "Highly incompatible:" + "\n" + NewLine;
+            ModConflictsMessage += NewLine + "Highly incompatible:" + "\n" + NewLine;
             for (int i = 0; i < LoadOrder.Count; i++)
             {
                 if (IncompatibleMods.Contains(LoadOrder[i].PackageId))
                 {
-                    ModConflictsMessage = ModConflictsMessage + LoadOrder[i].Name + "\n";
+                    ModConflictsMessage += LoadOrder[i].Name + "\n";
                     Conflictingmods = true;
                 }
             }
-            if (!Conflictingmods) ModConflictsMessage = ModConflictsMessage + "No Conflicts detected :D" + "\n";
+            if (!Conflictingmods) ModConflictsMessage +=  "No Conflicts detected :D" + "\n";
 
-            ModConflictsMessage = ModConflictsMessage + NewLine + "Other (potential) incompatibilities:" + "\n" + NewLine + "Check out the wiki on github for more information" + "\n" + "_______________________";
+            ModConflictsMessage += NewLine + "Other (potential) incompatibilities:" + "\n" + NewLine + "Check out the wiki on github for more information" + "\n" + "_______________________";
             Dialog_MessageBox window2 = new Dialog_MessageBox(ModConflictsMessage, "Ill take my chances", null, "Disable this alert in settings", null, "RimThreaded Mod Conflicts detected:", true);
             if (WrongLoadOrder || Conflictingmods) Find.WindowStack.Add(window2);
         }

--- a/Source/RimThreadedMod.cs
+++ b/Source/RimThreadedMod.cs
@@ -104,9 +104,6 @@ namespace RimThreaded
             if (RTpos != (LoadOrder.Count - 1))
             {
                 WrongLoadOrder = true;
-            }
-            if (WrongLoadOrder)
-            {
                 ModConflictsMessage = NewLine + "Critical incompatibility:" + Environment.NewLine + NewLine + "RimThreaded is NOT last in your mod load order, fix immediately." + Environment.NewLine;
             }
             ModConflictsMessage = ModConflictsMessage + NewLine + "Highly incompatible:" + Environment.NewLine + NewLine;
@@ -121,7 +118,7 @@ namespace RimThreaded
             if (!Conflictingmods) ModConflictsMessage = ModConflictsMessage + "No Conflicts detected :D" + Environment.NewLine;
 
             ModConflictsMessage = ModConflictsMessage + NewLine + "Other (potential) incompatibilities:" + Environment.NewLine + NewLine + "Check out the wiki on github for more information" + Environment.NewLine + "_______________________";
-            Dialog_MessageBox window2 = new Dialog_MessageBox(ModConflictsMessage, "Ill take my chances", null, "Disable this alert in settings", null, "RimThreaded Mod Conflicts detected:", true, null);
+            Dialog_MessageBox window2 = new Dialog_MessageBox(ModConflictsMessage, "Ill take my chances", null, "Disable this alert in settings", null, "RimThreaded Mod Conflicts detected:", true);
             if (WrongLoadOrder || Conflictingmods) Find.WindowStack.Add(window2);
         }
         private static Action DisableAlert() //Not implemented yet.

--- a/Source/RimThreadedMod.cs
+++ b/Source/RimThreadedMod.cs
@@ -11,6 +11,7 @@ namespace RimThreaded
     class RimThreadedMod : Mod
     {
         public static RimThreadedSettings Settings;
+        private static string modsText = "";
         public RimThreadedMod(ModContentPack content) : base(content)
         {
             Settings = GetSettings<RimThreadedSettings>();
@@ -41,7 +42,7 @@ namespace RimThreaded
         }
         public static string getPotentialModConflicts()
         {
-            string modsText = "";
+            if (modsText.Length != 0) return modsText;
             IEnumerable<MethodBase> originalMethods = Harmony.GetAllPatchedMethods();
 
             foreach (MethodBase originalMethod in originalMethods)

--- a/Source/RimThreadedMod.cs
+++ b/Source/RimThreadedMod.cs
@@ -93,34 +93,34 @@ namespace RimThreaded
 
         public static void getPotentialModConflicts_2()
         {
-            string[] IncompatibleMods = { "biomesteam.biomesislands", "mlie.bestmix", "rwmt.Multiplayer", "pyrce.terrain.movement.modkit" }; //Add/Remove mods here.
             bool WrongLoadOrder = false;
             bool Conflictingmods = false;
             string ModConflictsMessage = "";
-            int RTpos = LoadedModManager.RunningModsListForReading.FindIndex(i => i.PackageId == "majorhoff.rimthreaded");
-            int LoadOrderLength = LoadedModManager.RunningModsListForReading.Count;
-            if (RTpos != (LoadOrderLength - 1))
+            string[] IncompatibleMods = { "biomesteam.biomesislands", "mlie.bestmix", "rwmt.Multiplayer", "pyrce.terrain.movement.modkit" }; //Add/Remove mods here.
+            string NewLine = "_______________________" + Environment.NewLine + Environment.NewLine;
+            var LoadOrder = LoadedModManager.RunningModsListForReading;
+            int RTpos = LoadOrder.FindIndex(i => i.PackageId == "majorhoff.rimthreaded");
+
+            if (RTpos != (LoadOrder.Count - 1))
             {
                 WrongLoadOrder = true;
             }
             if (WrongLoadOrder)
             {
-                ModConflictsMessage = "_______________________" + Environment.NewLine + Environment.NewLine + "Critical incompatibility:" + Environment.NewLine + "_______________________" +
-                                      Environment.NewLine + Environment.NewLine + "RimThreaded is NOT last in your mod load order, fix immediately." + Environment.NewLine;
+                ModConflictsMessage = NewLine + "Critical incompatibility:" + Environment.NewLine + NewLine + "RimThreaded is NOT last in your mod load order, fix immediately." + Environment.NewLine;
             }
-            ModConflictsMessage = ModConflictsMessage + "_______________________" + Environment.NewLine + "" + Environment.NewLine + "Highly incompatible:" + Environment.NewLine + "_______________________" + Environment.NewLine + Environment.NewLine;
-            for (int i = 0; i < LoadOrderLength; i++)
+            ModConflictsMessage = ModConflictsMessage + NewLine + "Highly incompatible:" + Environment.NewLine + NewLine;
+            for (int i = 0; i < LoadOrder.Count; i++)
             {
-                if (IncompatibleMods.Contains(LoadedModManager.RunningModsListForReading[i].PackageId))
+                if (IncompatibleMods.Contains(LoadOrder[i].PackageId))
                 {
-                    ModConflictsMessage = ModConflictsMessage + LoadedModManager.RunningModsListForReading[i].Name + Environment.NewLine;
+                    ModConflictsMessage = ModConflictsMessage + LoadOrder[i].Name + Environment.NewLine;
                     Conflictingmods = true;
                 }
             }
             if (!Conflictingmods) ModConflictsMessage = ModConflictsMessage + "No Conflicts detected :D" + Environment.NewLine;
 
-            ModConflictsMessage = ModConflictsMessage + "_______________________" + Environment.NewLine + Environment.NewLine + "Other (potential) incompatibilities:" + Environment.NewLine + "_______________________" + Environment.NewLine +
-                                  Environment.NewLine + "Check out the wiki on github for more information" + Environment.NewLine + "_______________________";
+            ModConflictsMessage = ModConflictsMessage + NewLine + "Other (potential) incompatibilities:" + Environment.NewLine + NewLine + "Check out the wiki on github for more information" + Environment.NewLine + "_______________________";
             Dialog_MessageBox window2 = new Dialog_MessageBox(ModConflictsMessage, "Ill take my chances", null, "Disable this alert in settings", null, "RimThreaded Mod Conflicts detected:", true, null);
             if (WrongLoadOrder || Conflictingmods) Find.WindowStack.Add(window2);
         }

--- a/Source/RimThreadedMod.cs
+++ b/Source/RimThreadedMod.cs
@@ -53,11 +53,10 @@ namespace RimThreaded
                     bool isRimThreadedPrefixed = false;
                     foreach (Patch patch in patches.Prefixes)
                     {
-
                         if (patch.owner.Equals("majorhoff.rimthreaded") && !RimThreadedHarmony.nonDestructivePrefixes.Contains(patch.PatchMethod) && (patches.Prefixes.Count > 1 || patches.Postfixes.Count > 0 || patches.Transpilers.Count > 0))
                         {
                             isRimThreadedPrefixed = true;
-                            modsText += "\n  ---Patch method: " + patch.PatchMethod.DeclaringType.FullName + " " + patch.PatchMethod + "---\n";
+                            modsText += "\n  ---Patch method: " + patch.PatchMethod.DeclaringType?.FullName + " " + patch.PatchMethod + "---\n";
                             modsText += "  RimThreaded priority: " + patch.priority + "\n";
                             break;
                         }
@@ -97,27 +96,27 @@ namespace RimThreaded
             bool Conflictingmods = false;
             string ModConflictsMessage = "";
             string[] IncompatibleMods = { "biomesteam.biomesislands", "mlie.bestmix", "rwmt.Multiplayer", "pyrce.terrain.movement.modkit" }; //Add/Remove mods here.
-            string NewLine = "_______________________" + Environment.NewLine + Environment.NewLine;
+            string NewLine = "_______________________" + "\n" + "\n";
             var LoadOrder = LoadedModManager.RunningModsListForReading;
             int RTpos = LoadOrder.FindIndex(i => i.PackageId == "majorhoff.rimthreaded");
 
             if (RTpos != (LoadOrder.Count - 1))
             {
                 WrongLoadOrder = true;
-                ModConflictsMessage = NewLine + "Critical incompatibility:" + Environment.NewLine + NewLine + "RimThreaded is NOT last in your mod load order, fix immediately." + Environment.NewLine;
+                ModConflictsMessage = NewLine + "Critical incompatibility:" + "\n" + NewLine + "RimThreaded is NOT last in your mod load order, fix immediately." + "\n";
             }
-            ModConflictsMessage = ModConflictsMessage + NewLine + "Highly incompatible:" + Environment.NewLine + NewLine;
+            ModConflictsMessage = ModConflictsMessage + NewLine + "Highly incompatible:" + "\n" + NewLine;
             for (int i = 0; i < LoadOrder.Count; i++)
             {
                 if (IncompatibleMods.Contains(LoadOrder[i].PackageId))
                 {
-                    ModConflictsMessage = ModConflictsMessage + LoadOrder[i].Name + Environment.NewLine;
+                    ModConflictsMessage = ModConflictsMessage + LoadOrder[i].Name + "\n";
                     Conflictingmods = true;
                 }
             }
-            if (!Conflictingmods) ModConflictsMessage = ModConflictsMessage + "No Conflicts detected :D" + Environment.NewLine;
+            if (!Conflictingmods) ModConflictsMessage = ModConflictsMessage + "No Conflicts detected :D" + "\n";
 
-            ModConflictsMessage = ModConflictsMessage + NewLine + "Other (potential) incompatibilities:" + Environment.NewLine + NewLine + "Check out the wiki on github for more information" + Environment.NewLine + "_______________________";
+            ModConflictsMessage = ModConflictsMessage + NewLine + "Other (potential) incompatibilities:" + "\n" + NewLine + "Check out the wiki on github for more information" + "\n" + "_______________________";
             Dialog_MessageBox window2 = new Dialog_MessageBox(ModConflictsMessage, "Ill take my chances", null, "Disable this alert in settings", null, "RimThreaded Mod Conflicts detected:", true);
             if (WrongLoadOrder || Conflictingmods) Find.WindowStack.Add(window2);
         }

--- a/Source/RimThreadedMod.cs
+++ b/Source/RimThreadedMod.cs
@@ -3,15 +3,8 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using System.Text;
-using System.Threading.Tasks;
 using Verse;
 using UnityEngine;
-using Verse.AI;
-using RimWorld;
-using Verse.Sound;
-using RimWorld.Planet;
-using System.IO;
 
 namespace RimThreaded 
 { 
@@ -45,13 +38,12 @@ namespace RimThreaded
             RimThreaded.timeSpeedFast = Settings.timeSpeedFast;
             RimThreaded.timeSpeedSuperfast = Settings.timeSpeedSuperfast;
             RimThreaded.timeSpeedUltrafast = Settings.timeSpeedUltrafast;
-
         }
-
         public static string getPotentialModConflicts()
         {
             string modsText = "";
             IEnumerable<MethodBase> originalMethods = Harmony.GetAllPatchedMethods();
+
             foreach (MethodBase originalMethod in originalMethods)
             {
                 Patches patches = Harmony.GetPatchInfo(originalMethod);
@@ -99,12 +91,49 @@ namespace RimThreaded
             return modsText;
         }
 
+        public static void getPotentialModConflicts_2()
+        {
+            string[] IncompatibleMods = { "biomesteam.biomesislands", "mlie.bestmix", "rwmt.Multiplayer", "pyrce.terrain.movement.modkit" }; //Add/Remove mods here.
+            bool WrongLoadOrder = false;
+            bool Conflictingmods = false;
+            string ModConflictsMessage = "";
+            int RTpos = LoadedModManager.RunningModsListForReading.FindIndex(i => i.PackageId == "majorhoff.rimthreaded");
+            int LoadOrderLength = LoadedModManager.RunningModsListForReading.Count;
+            if (RTpos != (LoadOrderLength - 1))
+            {
+                WrongLoadOrder = true;
+            }
+            if (WrongLoadOrder)
+            {
+                ModConflictsMessage = "_______________________" + Environment.NewLine + Environment.NewLine + "Critical incompatibility:" + Environment.NewLine + "_______________________" +
+                                      Environment.NewLine + Environment.NewLine + "RimThreaded is NOT last in your mod load order, fix immediately." + Environment.NewLine;
+            }
+            ModConflictsMessage = ModConflictsMessage + "_______________________" + Environment.NewLine + "" + Environment.NewLine + "Highly incompatible:" + Environment.NewLine + "_______________________" + Environment.NewLine + Environment.NewLine;
+            for (int i = 0; i < LoadOrderLength; i++)
+            {
+                if (IncompatibleMods.Contains(LoadedModManager.RunningModsListForReading[i].PackageId))
+                {
+                    ModConflictsMessage = ModConflictsMessage + LoadedModManager.RunningModsListForReading[i].Name + Environment.NewLine;
+                    Conflictingmods = true;
+                }
+            }
+            if (!Conflictingmods) ModConflictsMessage = ModConflictsMessage + "No Conflicts detected :D" + Environment.NewLine;
+
+            ModConflictsMessage = ModConflictsMessage + "_______________________" + Environment.NewLine + Environment.NewLine + "Other (potential) incompatibilities:" + Environment.NewLine + "_______________________" + Environment.NewLine +
+                                  Environment.NewLine + "Check out the wiki on github for more information" + Environment.NewLine + "_______________________";
+            Dialog_MessageBox window2 = new Dialog_MessageBox(ModConflictsMessage, "Ill take my chances", null, "Disable this alert in settings", null, "RimThreaded Mod Conflicts detected:", true, null);
+            if (WrongLoadOrder || Conflictingmods) Find.WindowStack.Add(window2);
+        }
+        private static Action DisableAlert() //Not implemented yet.
+        {
+            RimThreadedMod.Settings.showModConflictsAlert = false;
+            return null;
+        }
         public override string SettingsCategory()
         {
             return "RimThreaded";
 
         }
-
     }
 
 }

--- a/Source/RimThreadedSettings.cs
+++ b/Source/RimThreadedSettings.cs
@@ -21,6 +21,7 @@ namespace RimThreaded
         public bool disablesomealets = false;
         public bool disablelimits = false;
         public bool disableforcedslowdowns = false;
+        public bool showModConflictsAlert = true;
         public float scrollViewHeight;
         public Vector2 scrollPosition;
         public string modsText = "";
@@ -48,6 +49,7 @@ namespace RimThreaded
             Scribe_Values.Look(ref disablesomealets, "disablesomealets", false);
             Scribe_Values.Look(ref disablelimits, "disablelimits", false);
             Scribe_Values.Look(ref disableforcedslowdowns, "disableforcedslowdowns", false);
+            Scribe_Values.Look(ref showModConflictsAlert, "showModConflictsAlert", true);
 
         }
 
@@ -71,6 +73,8 @@ namespace RimThreaded
             Widgets.CheckboxLabeled(listing_Standard.GetRect(27f), "Disable alert updates at 4x speed:", ref disablesomealets);
             Widgets.CheckboxLabeled(listing_Standard.GetRect(27f), "Disable thread/worker limit (debugging):", ref disablelimits);
             Widgets.CheckboxLabeled(listing_Standard.GetRect(27f), "Disable slowdown on combat:", ref disableforcedslowdowns);
+            Widgets.CheckboxLabeled(listing_Standard.GetRect(27f), "Show alert when conflicting mods are detected:", ref showModConflictsAlert);
+
             Widgets.TextAreaScrollable(listing_Standard.GetRect(300f), modsText, ref scrollPos);
             listing_Standard.EndScrollView(ref viewRect);
             scrollViewHeight = viewRect.height;

--- a/Source/RimThreadedSettings.cs
+++ b/Source/RimThreadedSettings.cs
@@ -20,7 +20,7 @@ namespace RimThreaded
         public string timeSpeedUltrafastBuffer = "150";
         public bool disablesomealets = false;
         public bool disablelimits = false;
-        public bool disableforcedslowdowns = false;
+        public bool disableforcedslowdowns = true;
         public bool showModConflictsAlert = true;
         public float scrollViewHeight;
         public Vector2 scrollPosition;
@@ -48,7 +48,7 @@ namespace RimThreaded
             Scribe_Values.Look(ref timeSpeedUltrafastBuffer, "timeSpeedUltrafastBuffer", "150");
             Scribe_Values.Look(ref disablesomealets, "disablesomealets", false);
             Scribe_Values.Look(ref disablelimits, "disablelimits", false);
-            Scribe_Values.Look(ref disableforcedslowdowns, "disableforcedslowdowns", false);
+            Scribe_Values.Look(ref disableforcedslowdowns, "disableforcedslowdowns", true);
             Scribe_Values.Look(ref showModConflictsAlert, "showModConflictsAlert", true);
 
         }


### PR DESCRIPTION
Add warning when running incompatible mods.
Add warning when RimThreaded is not last in load order.

getPotentialModConflicts_2(); needs to be moved out of alertsReadout.
Unable to save setting in window (Unimplemented action function)