### PR TITLE
Settings change to prevent Vanquisher02 fuckery

### DIFF
--- a/Source/RimThreadedMod.cs
+++ b/Source/RimThreadedMod.cs
@@ -40,7 +40,7 @@ namespace RimThreaded
                 RimThreaded.maxThreads = Settings.disablelimits ? Math.Max(Settings.maxThreads, 1) : Math.Min(Math.Max(Settings.maxThreads, 1), 128);
                 RimThreaded.RestartAllWorkerThreads();
             }
-            RimThreaded.timeoutMS = Settings.disablelimits ? Math.Max(Settings.timeoutMS, 1) : Math.Min(Math.Max(Settings.timeoutMS, 5000), 100000);
+            RimThreaded.timeoutMS = Settings.disablelimits ? Math.Max(Settings.timeoutMS, 1) : Math.Min(Math.Max(Settings.timeoutMS, 5000), 20000);
             RimThreaded.timeSpeedNormal = Settings.timeSpeedNormal;
             RimThreaded.timeSpeedFast = Settings.timeSpeedFast;
             RimThreaded.timeSpeedSuperfast = Settings.timeSpeedSuperfast;


### PR DESCRIPTION
Vanquisher02 found the higher limit of the timer setting causes catastrophic issues when set too high, our userbase for 2.0 will explode, which will include the lower tiers of the  Gaussian bell. Let's change the defaults to protect our future users and future discord mods