### PR TITLE
Rebuilt AttackTargetReservationManager + OneTickPool.

### DIFF
--- a/Source/1.3/replacements.json
+++ b/Source/1.3/replacements.json
@@ -35,6 +35,29 @@
       ]
     },
     {
+      "ClassName": "Verse.AutoSlaughterManager",
+      "ThreadStatics": [
+        {
+          "FieldName": "tmpAnimals"
+        },
+        {
+          "FieldName": "tmpAnimalsMale"
+        },
+        {
+          "FieldName": "tmpAnimalsMaleYoung"
+        },
+        {
+          "FieldName": "tmpAnimalsFemale"
+        },
+        {
+          "FieldName": "tmpAnimalsFemaleYoung"
+        },
+        {
+          "FieldName": "tmpAnimalsPregnant"
+        }
+      ]
+    },
+    {
       "ClassName": "RimWorld.BeautyUtility",
       "ThreadStatics": [
         {

--- a/Source/AttackTargetReservationManager_Patch.cs
+++ b/Source/AttackTargetReservationManager_Patch.cs
@@ -1,63 +1,136 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Reflection;
 using RimWorld;
 using Verse;
 using Verse.AI;
 using static Verse.AI.AttackTargetReservationManager;
+//using static HarmonyLib.AccessTools;
+//using HarmonyLib;
 
 namespace RimThreaded
 {
 
-    public class AttackTargetReservationManager_Patch
+	public class AttackTargetReservationManager_Patch // rebuild to not create new tmp lists and to recycle reservations.
 	{
 		internal static void RunDestructivePatches()
 		{
 			Type original = typeof(AttackTargetReservationManager);
 			Type patched = typeof(AttackTargetReservationManager_Patch);
-			RimThreadedHarmony.Prefix(original, patched, "FirstReservationFor");
-			RimThreadedHarmony.Prefix(original, patched, "ReleaseClaimedBy");
-			RimThreadedHarmony.Prefix(original, patched, "ReleaseAllForTarget");
-			RimThreadedHarmony.Prefix(original, patched, "ReleaseAllClaimedBy");
-			RimThreadedHarmony.Prefix(original, patched, "GetReservationsCount");
-			RimThreadedHarmony.Prefix(original, patched, "Reserve");
-			RimThreadedHarmony.Prefix(original, patched, "IsReservedBy");
+			RimThreadedHarmony.Prefix(original, patched, nameof(FirstReservationFor));
+			RimThreadedHarmony.Prefix(original, patched, nameof(ReleaseClaimedBy));
+			RimThreadedHarmony.Prefix(original, patched, nameof(ReleaseAllForTarget));
+			RimThreadedHarmony.Prefix(original, patched, nameof(ReleaseAllClaimedBy));
+			RimThreadedHarmony.Prefix(original, patched, nameof(GetReservationsCount));
+			RimThreadedHarmony.Prefix(original, patched, nameof(Reserve));
+			RimThreadedHarmony.Prefix(original, patched, nameof(IsReservedBy));
+			RimThreadedHarmony.Prefix(original, patched, nameof(Release));
 		}
-
-		public static bool ReleaseAllForTarget(AttackTargetReservationManager __instance, IAttackTarget target)
+/*		internal static void RunNonDestructivePatches()
 		{
-			lock (RimThreaded.map_AttackTargetReservationManager_reservations_Lock)
+			Type original = typeof(AttackTargetReservationManager);
+			Type patched = typeof(AttackTargetReservationManager_Patch);
+			ConstructorInfo oCtor = Constructor(original, new Type[] { typeof(Map)});
+            MethodInfo pMethod = Method(patched, nameof(ATRMConstructor));
+			RimThreadedHarmony.harmony.Patch(oCtor, postfix: new HarmonyMethod(pMethod));
+		}*/
+
+		[ThreadStatic] static public Dictionary<AttackTargetReservationManager, List<AttackTargetReservation>> newAttackTargetReservations;
+
+		internal static void InitializeThreadStatics()
+		{
+			newAttackTargetReservations = new Dictionary<AttackTargetReservationManager, List<AttackTargetReservation>>();
+		}
+		/*public static void ATRMConstructor(AttackTargetReservationManager __instance, Map map)
+        {
+			newAttackTargetReservations[__instance] = new List<AttackTargetReservation>();//only 1 thread will have this added big mistake maybe this can be done in another way.
+		}*/
+		public static bool Release(AttackTargetReservationManager __instance, Pawn claimant, Job job, IAttackTarget target)
+		{
+			lock (__instance)
 			{
-				List<AttackTargetReservation> snapshotReservations = __instance.reservations;
-				List<AttackTargetReservation> newAttackTargetReservations = new List<AttackTargetReservation>(snapshotReservations.Count);
-				for (int i = 0; i < snapshotReservations.Count - 1; i++)
+				if (target == null)
 				{
-					AttackTargetReservation attackTargetReservation = snapshotReservations[i];				
-					if (attackTargetReservation.target != target)
+					Log.Warning(string.Concat(claimant, " tried to release reservation on null attack target."));
+					return false;
+				}
+				List<AttackTargetReservation> snapshotReservations = __instance.reservations;
+				if (!newAttackTargetReservations.ContainsKey(__instance))
+                {
+					newAttackTargetReservations[__instance] = new List<AttackTargetReservation>();
+				}
+				newAttackTargetReservations[__instance].Clear();
+				for (int i = 0; i < snapshotReservations.Count; i++)
+				{
+					AttackTargetReservation attackTargetReservation = snapshotReservations[i];
+					if (attackTargetReservation.target != target || attackTargetReservation.claimant != claimant || attackTargetReservation.job != job)
 					{
-						newAttackTargetReservations.Add(attackTargetReservation);
+						newAttackTargetReservations[__instance].Add(attackTargetReservation);
+					}
+					else
+					{
+						SimplePool<AttackTargetReservation>.Return(attackTargetReservation);
 					}
 				}
-                __instance.reservations = newAttackTargetReservations;
+				__instance.reservations.Clear();
+				__instance.reservations.AddRange(newAttackTargetReservations[__instance]);
 			}
-			
+			return false;
+		}
+		public static bool ReleaseAllForTarget(AttackTargetReservationManager __instance, IAttackTarget target)
+		{
+			lock (__instance)
+			{
+				List<AttackTargetReservation> snapshotReservations = __instance.reservations;
+				if (!newAttackTargetReservations.ContainsKey(__instance))
+				{
+					newAttackTargetReservations[__instance] = new List<AttackTargetReservation>();
+				}
+				newAttackTargetReservations[__instance].Clear();
+
+				for (int i = 0; i < snapshotReservations.Count - 1; i++)
+				{
+					AttackTargetReservation attackTargetReservation = snapshotReservations[i];
+					if (attackTargetReservation.target != target)
+					{
+						newAttackTargetReservations[__instance].Add(attackTargetReservation);
+					}
+					else
+					{
+						SimplePool<AttackTargetReservation>.Return(attackTargetReservation);
+					}
+				}
+				__instance.reservations.Clear();
+				__instance.reservations.AddRange(newAttackTargetReservations[__instance]);
+			}
+
 			return false;
 		}
 
 		public static bool ReleaseAllClaimedBy(AttackTargetReservationManager __instance, Pawn claimant)
 		{
-			lock (RimThreaded.map_AttackTargetReservationManager_reservations_Lock)
+			lock (__instance)
 			{
 				List<AttackTargetReservation> snapshotReservations = __instance.reservations;
-				List<AttackTargetReservation> newAttackTargetReservations = new List<AttackTargetReservation>(snapshotReservations.Count);
+				if (!newAttackTargetReservations.ContainsKey(__instance))
+				{
+					newAttackTargetReservations[__instance] = new List<AttackTargetReservation>();
+				}
+				newAttackTargetReservations[__instance].Clear();
 				for (int i = 0; i < snapshotReservations.Count - 1; i++)
 				{
 					AttackTargetReservation attackTargetReservation = snapshotReservations[i];
 					if (attackTargetReservation.claimant != claimant)
 					{
-						newAttackTargetReservations.Add(attackTargetReservation);
+						newAttackTargetReservations[__instance].Add(attackTargetReservation);
+					}
+					else
+					{
+						SimplePool<AttackTargetReservation>.Return(attackTargetReservation);
 					}
 				}
-                __instance.reservations = newAttackTargetReservations;
+				__instance.reservations.Clear();
+				__instance.reservations.AddRange(newAttackTargetReservations[__instance]);
 			}
 			return false;
 		}
@@ -71,18 +144,24 @@ namespace RimThreaded
 			}
 			else if (!__instance.IsReservedBy(claimant, target))
 			{
-                AttackTargetReservation attackTargetReservation = new AttackTargetReservation
-                {
-                    target = target,
-                    claimant = claimant,
-                    job = job
-                };
-                lock (RimThreaded.map_AttackTargetReservationManager_reservations_Lock)
+
+				AttackTargetReservation attackTargetReservation = SimplePool<AttackTargetReservation>.Get();
+				attackTargetReservation.target = target;
+				attackTargetReservation.claimant = claimant;
+				attackTargetReservation.job = job;
+
+				lock (__instance)
 				{
-                    __instance.reservations = new List<AttackTargetReservation>(__instance.reservations)
-                    {
-                        attackTargetReservation
-                    };
+					if (!newAttackTargetReservations.ContainsKey(__instance))
+					{
+						newAttackTargetReservations[__instance] = new List<AttackTargetReservation>();
+					}
+					newAttackTargetReservations[__instance].Clear();
+					newAttackTargetReservations[__instance].AddRange(__instance.reservations);
+					newAttackTargetReservations[__instance].Add(attackTargetReservation);
+
+					__instance.reservations.Clear();
+					__instance.reservations.AddRange(newAttackTargetReservations[__instance]);
 				}
 			}
 			return false;
@@ -90,32 +169,41 @@ namespace RimThreaded
 
 		public static bool FirstReservationFor(AttackTargetReservationManager __instance, ref IAttackTarget __result, Pawn claimant)
 		{
-            List<AttackTargetReservation> snapshotReservations = __instance.reservations;
+			List<AttackTargetReservation> snapshotReservations = __instance.reservations;
 			for (int i = snapshotReservations.Count - 1; i >= 0; i--)
 			{
-                AttackTargetReservation reservation = snapshotReservations[i];
-                if (reservation.claimant != claimant) continue;
-                __result = reservation.target;
-                return false;
-            }			
+				AttackTargetReservation reservation = snapshotReservations[i];
+				if (reservation.claimant != claimant) continue;
+				__result = reservation.target;
+				return false;
+			}
 			__result = null;
 			return false;
 		}
 		public static bool ReleaseClaimedBy(AttackTargetReservationManager __instance, Pawn claimant, Job job)
 		{
-			lock (RimThreaded.map_AttackTargetReservationManager_reservations_Lock)
+			lock (__instance)
 			{
 				List<AttackTargetReservation> snapshotReservations = __instance.reservations;
-				List<AttackTargetReservation> newAttackTargetReservations = new List<AttackTargetReservation>(snapshotReservations.Count);
+				if (!newAttackTargetReservations.ContainsKey(__instance))
+				{
+					newAttackTargetReservations[__instance] = new List<AttackTargetReservation>();
+				}
+				newAttackTargetReservations[__instance].Clear();
 				for (int i = 0; i < snapshotReservations.Count - 1; i++)
 				{
 					AttackTargetReservation attackTargetReservation = snapshotReservations[i];
 					if (attackTargetReservation.claimant != claimant || attackTargetReservation.job != job)
 					{
-						newAttackTargetReservations.Add(attackTargetReservation);
+						newAttackTargetReservations[__instance].Add(attackTargetReservation);
+					}
+					else
+					{
+						SimplePool<AttackTargetReservation>.Return(attackTargetReservation);
 					}
 				}
-                __instance.reservations = newAttackTargetReservations;
+				__instance.reservations.Clear();
+				__instance.reservations.AddRange(newAttackTargetReservations[__instance]);
 			}
 			return false;
 		}
@@ -125,10 +213,10 @@ namespace RimThreaded
 			for (int i = 0; i < snapshotReservations.Count; i++)
 			{
 				AttackTargetReservation attackTargetReservation = snapshotReservations[i];
-                if (attackTargetReservation.target != target || attackTargetReservation.claimant != claimant) continue;
-                __result = true;
-                return false;
-            }
+				if (attackTargetReservation.target != target || attackTargetReservation.claimant != claimant) continue;
+				__result = true;
+				return false;
+			}
 
 			__result = false;
 			return false;
@@ -146,10 +234,8 @@ namespace RimThreaded
 					num++;
 				}
 			}
-
 			__result = num;
 			return false;
 		}
-
-    }
+	}
 }

--- a/Source/AttackTargetReservationManager_Patch.cs
+++ b/Source/AttackTargetReservationManager_Patch.cs
@@ -35,11 +35,11 @@ namespace RimThreaded
 			RimThreadedHarmony.harmony.Patch(oCtor, postfix: new HarmonyMethod(pMethod));
 		}*/
 
-		[ThreadStatic] static public Dictionary<AttackTargetReservationManager, List<AttackTargetReservation>> newAttackTargetReservations;
+		[ThreadStatic] static public List<AttackTargetReservation> newAttackTargetReservations;
 
 		internal static void InitializeThreadStatics()
 		{
-			newAttackTargetReservations = new Dictionary<AttackTargetReservationManager, List<AttackTargetReservation>>();
+			newAttackTargetReservations = new List<AttackTargetReservation>();
 		}
 		/*public static void ATRMConstructor(AttackTargetReservationManager __instance, Map map)
         {
@@ -55,25 +55,22 @@ namespace RimThreaded
 					return false;
 				}
 				List<AttackTargetReservation> snapshotReservations = __instance.reservations;
-				if (!newAttackTargetReservations.ContainsKey(__instance))
-                {
-					newAttackTargetReservations[__instance] = new List<AttackTargetReservation>();
-				}
-				newAttackTargetReservations[__instance].Clear();
+				
+				newAttackTargetReservations.Clear();
 				for (int i = 0; i < snapshotReservations.Count; i++)
 				{
 					AttackTargetReservation attackTargetReservation = snapshotReservations[i];
 					if (attackTargetReservation.target != target || attackTargetReservation.claimant != claimant || attackTargetReservation.job != job)
 					{
-						newAttackTargetReservations[__instance].Add(attackTargetReservation);
+						newAttackTargetReservations.Add(attackTargetReservation);
 					}
 					else
 					{
-						SimplePool<AttackTargetReservation>.Return(attackTargetReservation);
+						SimplePool_Patch<AttackTargetReservation>.Return(attackTargetReservation);
 					}
 				}
 				__instance.reservations.Clear();
-				__instance.reservations.AddRange(newAttackTargetReservations[__instance]);
+				__instance.reservations.AddRange(newAttackTargetReservations);
 			}
 			return false;
 		}
@@ -82,26 +79,23 @@ namespace RimThreaded
 			lock (__instance)
 			{
 				List<AttackTargetReservation> snapshotReservations = __instance.reservations;
-				if (!newAttackTargetReservations.ContainsKey(__instance))
-				{
-					newAttackTargetReservations[__instance] = new List<AttackTargetReservation>();
-				}
-				newAttackTargetReservations[__instance].Clear();
+
+				newAttackTargetReservations.Clear();
 
 				for (int i = 0; i < snapshotReservations.Count - 1; i++)
 				{
 					AttackTargetReservation attackTargetReservation = snapshotReservations[i];
 					if (attackTargetReservation.target != target)
 					{
-						newAttackTargetReservations[__instance].Add(attackTargetReservation);
+						newAttackTargetReservations.Add(attackTargetReservation);
 					}
 					else
 					{
-						SimplePool<AttackTargetReservation>.Return(attackTargetReservation);
+						SimplePool_Patch<AttackTargetReservation>.Return(attackTargetReservation);
 					}
 				}
 				__instance.reservations.Clear();
-				__instance.reservations.AddRange(newAttackTargetReservations[__instance]);
+				__instance.reservations.AddRange(newAttackTargetReservations);
 			}
 
 			return false;
@@ -112,25 +106,22 @@ namespace RimThreaded
 			lock (__instance)
 			{
 				List<AttackTargetReservation> snapshotReservations = __instance.reservations;
-				if (!newAttackTargetReservations.ContainsKey(__instance))
-				{
-					newAttackTargetReservations[__instance] = new List<AttackTargetReservation>();
-				}
-				newAttackTargetReservations[__instance].Clear();
+
+				newAttackTargetReservations.Clear();
 				for (int i = 0; i < snapshotReservations.Count - 1; i++)
 				{
 					AttackTargetReservation attackTargetReservation = snapshotReservations[i];
 					if (attackTargetReservation.claimant != claimant)
 					{
-						newAttackTargetReservations[__instance].Add(attackTargetReservation);
+						newAttackTargetReservations.Add(attackTargetReservation);
 					}
 					else
 					{
-						SimplePool<AttackTargetReservation>.Return(attackTargetReservation);
+						SimplePool_Patch<AttackTargetReservation>.Return(attackTargetReservation);
 					}
 				}
 				__instance.reservations.Clear();
-				__instance.reservations.AddRange(newAttackTargetReservations[__instance]);
+				__instance.reservations.AddRange(newAttackTargetReservations);
 			}
 			return false;
 		}
@@ -145,23 +136,20 @@ namespace RimThreaded
 			else if (!__instance.IsReservedBy(claimant, target))
 			{
 
-				AttackTargetReservation attackTargetReservation = SimplePool<AttackTargetReservation>.Get();
+				AttackTargetReservation attackTargetReservation = SimplePool_Patch<AttackTargetReservation>.Get();
 				attackTargetReservation.target = target;
 				attackTargetReservation.claimant = claimant;
 				attackTargetReservation.job = job;
 
 				lock (__instance)
 				{
-					if (!newAttackTargetReservations.ContainsKey(__instance))
-					{
-						newAttackTargetReservations[__instance] = new List<AttackTargetReservation>();
-					}
-					newAttackTargetReservations[__instance].Clear();
-					newAttackTargetReservations[__instance].AddRange(__instance.reservations);
-					newAttackTargetReservations[__instance].Add(attackTargetReservation);
+
+					newAttackTargetReservations.Clear();
+					newAttackTargetReservations.AddRange(__instance.reservations);
+					newAttackTargetReservations.Add(attackTargetReservation);
 
 					__instance.reservations.Clear();
-					__instance.reservations.AddRange(newAttackTargetReservations[__instance]);
+					__instance.reservations.AddRange(newAttackTargetReservations);
 				}
 			}
 			return false;
@@ -185,25 +173,22 @@ namespace RimThreaded
 			lock (__instance)
 			{
 				List<AttackTargetReservation> snapshotReservations = __instance.reservations;
-				if (!newAttackTargetReservations.ContainsKey(__instance))
-				{
-					newAttackTargetReservations[__instance] = new List<AttackTargetReservation>();
-				}
-				newAttackTargetReservations[__instance].Clear();
+
+				newAttackTargetReservations.Clear();
 				for (int i = 0; i < snapshotReservations.Count - 1; i++)
 				{
 					AttackTargetReservation attackTargetReservation = snapshotReservations[i];
 					if (attackTargetReservation.claimant != claimant || attackTargetReservation.job != job)
 					{
-						newAttackTargetReservations[__instance].Add(attackTargetReservation);
+						newAttackTargetReservations.Add(attackTargetReservation);
 					}
 					else
 					{
-						SimplePool<AttackTargetReservation>.Return(attackTargetReservation);
+						SimplePool_Patch<AttackTargetReservation>.Return(attackTargetReservation);
 					}
 				}
 				__instance.reservations.Clear();
-				__instance.reservations.AddRange(newAttackTargetReservations[__instance]);
+				__instance.reservations.AddRange(newAttackTargetReservations);
 			}
 			return false;
 		}

--- a/Source/OneTickPool.cs
+++ b/Source/OneTickPool.cs
@@ -1,0 +1,43 @@
+﻿using System.Collections.Generic;
+using System.Threading;
+
+namespace RimThreaded
+{
+    /// <summary>
+    /// Use this class only when you can demonstrate an object dies after 1 tick and you can't track its life.
+    /// If you can track its life use the SimplePool instead.
+    /// </summary>
+    public static class OneTickPool<T> where T : new()
+    {
+        private static readonly List<T> ObjectsList = new List<T>();
+
+        public static int ObjectsCount => ObjectsList.Count;
+
+        private static int Pivot = -1;// everything to the left is being used, everything to the right is free.
+
+        /// <summary>
+        /// REMEMBER OBJECTS RETURNED FROM THIS MUST BE CLEARED
+        /// </summary>
+        public static T Get()
+        {
+            int index = Interlocked.Increment(ref Pivot);
+
+            if (index >= ObjectsCount)
+            {
+                lock (ObjectsList)
+                {
+                    while (index >= ObjectsCount)
+                    {
+                        ObjectsList.Add(new T());
+                    }
+                }
+            }
+            return ObjectsList[index];
+        }
+        public static void Tick()
+        {
+            Pivot = -1;
+        }
+
+    }
+}

--- a/Source/ReservationManager_Patch.cs
+++ b/Source/ReservationManager_Patch.cs
@@ -154,7 +154,7 @@ namespace RimThreaded
 			Dictionary<Pawn, List<Reservation>> reservationClaimantDict = getReservationClaimantDict(__instance);
 			if (!reservationClaimantDict.TryGetValue(claimant, out List<Reservation> reservationClaimantList))
 			{
-				lock (reservationClaimantDict)
+				lock (__instance)
 				{
 					if (!reservationClaimantDict.TryGetValue(claimant, out List<Reservation> reservationClaimantList2))
 					{

--- a/Source/ReservationManager_Patch.cs
+++ b/Source/ReservationManager_Patch.cs
@@ -753,7 +753,7 @@ namespace RimThreaded
 				//List<Reservation> newReservationClaimantList = new List<Reservation>();
 
 				newReservationClaimantList.Clear();//CHANGES
-				foreach (Reservation reservation in reservationClaimantList.ToArray())//????????????????????!
+				foreach (Reservation reservation in reservationClaimantList)
 				{
 					if (reservation.Job != job)
 					{

--- a/Source/ReservationManager_Patch.cs
+++ b/Source/ReservationManager_Patch.cs
@@ -89,11 +89,11 @@ namespace RimThreaded
 			return false;
 		}
 
-		private static List<Reservation> getReservationTargetList(Dictionary<LocalTargetInfo, List<Reservation>> reservationTargetDict, LocalTargetInfo target)
+		private static List<Reservation> getReservationTargetList(Dictionary<LocalTargetInfo, List<Reservation>> reservationTargetDict, LocalTargetInfo target, ReservationManager __instance)
 		{
 			if (!reservationTargetDict.TryGetValue(target, out List<Reservation> reservationTargetList))
 			{
-				lock (reservationTargetDict)
+				lock (__instance)
 				{
 					if (!reservationTargetDict.TryGetValue(target, out List<Reservation> reservationTargetList2))
 					{
@@ -134,7 +134,7 @@ namespace RimThreaded
 			Dictionary<LocalTargetInfo, List<Reservation>> reservationTargetDict = getReservationTargetDict(__instance);
 			if (!reservationTargetDict.TryGetValue(target, out List<Reservation> reservationTargetList))
 			{
-				lock (reservationTargetDict)
+				lock (__instance)
 				{
 					if (!reservationTargetDict.TryGetValue(target, out List<Reservation> reservationTargetList2))
 					{
@@ -538,7 +538,7 @@ namespace RimThreaded
 						//{
 						//    reservation
 						//};
-                        getReservationTargetList(reservationTargetDict, target).Add(reservation);
+                        getReservationTargetList(reservationTargetDict, target, __instance).Add(reservation);
                         reservationClaimantDict = getReservationClaimantDict(__instance);
                         //newReservationClaimantList =
                         //    new List<Reservation>(getReservationClaimantList(reservationClaimantDict, claimant))
@@ -589,7 +589,7 @@ namespace RimThreaded
 				//	{
 				//		reservation
 				//	};
-                getReservationTargetList(reservationTargetDict, target).Add(reservation);
+                getReservationTargetList(reservationTargetDict, target, __instance).Add(reservation);
                 reservationClaimantDict = getReservationClaimantDict(__instance);
 				//newReservationClaimantList = new List<Reservation>(getReservationClaimantList(reservationClaimantDict, claimant))
 				//	{
@@ -647,7 +647,7 @@ namespace RimThreaded
 
 
 					Dictionary<LocalTargetInfo, List<Reservation>> reservationTargetDict = getReservationTargetDict(__instance);
-					List<Reservation> reservationTargetList = getReservationTargetList(reservationTargetDict, target);
+					List<Reservation> reservationTargetList = getReservationTargetList(reservationTargetDict, target, __instance);
 
 					//List<Reservation> newReservationTargetList = new List<Reservation>();
 
@@ -691,7 +691,7 @@ namespace RimThreaded
 			Dictionary<LocalTargetInfo, List<Reservation>> reservationTargetDict = getReservationTargetDict(__instance);
 			lock (__instance)
 			{
-				List<Reservation> reservationTargetList = getReservationTargetList(reservationTargetDict, t.Position);
+				List<Reservation> reservationTargetList = getReservationTargetList(reservationTargetDict, t.Position, __instance);
 				//List<Reservation> newReservationTargetList = new List<Reservation>();
 
 				newReservationTargetList.Clear();
@@ -762,7 +762,7 @@ namespace RimThreaded
 					else
 					{
                         LocalTargetInfo target = reservation.Target;
-						List<Reservation> reservationTargetList = getReservationTargetList(reservationTargetDict, target);
+						List<Reservation> reservationTargetList = getReservationTargetList(reservationTargetDict, target, __instance);
 						//List<Reservation> newReservationTargetList = new List<Reservation>();
 
 						newReservationTargetList.Clear();
@@ -807,7 +807,7 @@ namespace RimThreaded
 				foreach (Reservation reservation in reservationClaimantList)
 				{
 					LocalTargetInfo target = reservation.Target;
-					List<Reservation> reservationTargetList = getReservationTargetList(reservationTargetDict, target);
+					List<Reservation> reservationTargetList = getReservationTargetList(reservationTargetDict, target, __instance);
 					//List<Reservation> newReservationTargetList = new List<Reservation>();
 
 					newReservationTargetList.Clear();
@@ -849,12 +849,15 @@ namespace RimThreaded
 				__result = LocalTargetInfo.Invalid;
 				return false;
 			}
-			List<Reservation> reservationClaimantList = getReservationClaimantList(__instance, claimant);			
-			foreach (Reservation reservation in reservationClaimantList)
-			{
-				__result = reservation.Target;
-				return false;
-			}			
+			lock (__instance)
+            {
+				List<Reservation> reservationClaimantList = getReservationClaimantList(__instance, claimant);
+				foreach (Reservation reservation in reservationClaimantList)
+				{
+					__result = reservation.Target;//how was this not happening before? Pawn_Patch.VerifyReservations
+					return false;
+				}
+			}					
 			__result = LocalTargetInfo.Invalid;
 			return false;
 		}

--- a/Source/ReservationManager_Patch.cs
+++ b/Source/ReservationManager_Patch.cs
@@ -10,13 +10,15 @@ using System;
 namespace RimThreaded
 {
 	[StaticConstructorOnStartup]
-	public class ReservationManager_Patch
+	public class ReservationManager_Patch//DO NOT TOUCH THE LISTS INSIDE HOFF TRYGET METHODS!!!
 	{
 		public static readonly Dictionary<ReservationManager, Dictionary<LocalTargetInfo, List<Reservation>>> reservationTargetDicts =
 			new Dictionary<ReservationManager, Dictionary<LocalTargetInfo, List<Reservation>>>();
 		public static readonly Dictionary<ReservationManager, Dictionary<Pawn, List<Reservation>>> reservationClaimantDicts =
 			new Dictionary<ReservationManager, Dictionary<Pawn, List<Reservation>>>();
 
+		[ThreadStatic] public static List<Reservation> newReservationClaimantList;//CHANGED
+		[ThreadStatic] public static List<Reservation> newReservationTargetList;//CHANGED
 		internal static void RunDestructivePatches()
 		{
 			Type original = typeof(ReservationManager);
@@ -40,6 +42,11 @@ namespace RimThreaded
 
 			//RimThreadedHarmony.Postfix(original, patched, "Release", "PostRelease");
 			//RimThreadedHarmony.Postfix(original, patched, "Release", "PostReleaseAllForTarget");
+		}
+		internal static void InitializeThreadStatics()//CHANGED
+		{
+			newReservationClaimantList = new List<Reservation>();
+			newReservationTargetList = new List<Reservation>();
 		}
 
 		public static bool ExposeData(ReservationManager __instance)
@@ -90,7 +97,7 @@ namespace RimThreaded
 				{
 					if (!reservationTargetDict.TryGetValue(target, out List<Reservation> reservationTargetList2))
 					{
-						reservationTargetList = new List<Reservation>();
+						reservationTargetList = new List<Reservation>();//FINE DON'T TOUCH
 						reservationTargetDict[target] = reservationTargetList;
 					}
 					else
@@ -101,24 +108,26 @@ namespace RimThreaded
 			}
 			return reservationTargetList;
 		}
-		private static List<Reservation> getReservationClaimantList(Dictionary<Pawn, List<Reservation>> reservationClaimantDict, Pawn claimant)
+		private static List<Reservation> getReservationClaimantList(Dictionary<Pawn, List<Reservation>> reservationClaimantDict, Pawn claimant, ReservationManager __instance)
 		{
-			if (!reservationClaimantDict.TryGetValue(claimant, out List<Reservation> reservationClaimantList))
-			{
-				lock (reservationClaimantDict)
+
+				if (!reservationClaimantDict.TryGetValue(claimant, out List<Reservation> reservationClaimantList))
 				{
-					if (!reservationClaimantDict.TryGetValue(claimant, out List<Reservation> reservationClaimantList2))
+					lock (__instance)
 					{
-						reservationClaimantList = new List<Reservation>();
-						reservationClaimantDict[claimant] = reservationClaimantList;
-					}
-					else
-					{
-						reservationClaimantList = reservationClaimantList2;
+						if (!reservationClaimantDict.TryGetValue(claimant, out List<Reservation> reservationClaimantList2))
+						{
+							reservationClaimantList = new List<Reservation>();//FINE DON'T TOUCH
+							reservationClaimantDict[claimant] = reservationClaimantList;
+						}
+						else
+						{
+							reservationClaimantList = reservationClaimantList2;
+						}
 					}
 				}
-			}
-			return reservationClaimantList;
+				return reservationClaimantList;
+
 		}
 		public static List<Reservation> getReservationTargetList(ReservationManager __instance, LocalTargetInfo target)
 		{
@@ -129,7 +138,7 @@ namespace RimThreaded
 				{
 					if (!reservationTargetDict.TryGetValue(target, out List<Reservation> reservationTargetList2))
 					{
-						reservationTargetList = new List<Reservation>();
+						reservationTargetList = new List<Reservation>();//FINE DON'T TOUCH
 						reservationTargetDict[target] = reservationTargetList;
 					}
 					else
@@ -149,7 +158,7 @@ namespace RimThreaded
 				{
 					if (!reservationClaimantDict.TryGetValue(claimant, out List<Reservation> reservationClaimantList2))
 					{
-						reservationClaimantList = new List<Reservation>();
+						reservationClaimantList = new List<Reservation>();//FINE DON'T TOUCH
 						reservationClaimantDict[claimant] = reservationClaimantList;
 					}
 					else
@@ -169,14 +178,14 @@ namespace RimThreaded
 					if (!reservationTargetDicts.TryGetValue(__instance, out Dictionary<LocalTargetInfo, List<Reservation>> reservationTargetDict2))
 					{
 						Log.Message("RimThreaded is building new Reservations Dictionary...");
-						reservationTargetDict = new Dictionary<LocalTargetInfo, List<Reservation>>();
-						Dictionary<Pawn, List<Reservation>> reservationClaimantDict = new Dictionary<Pawn, List<Reservation>>();
+						reservationTargetDict = new Dictionary<LocalTargetInfo, List<Reservation>>();//FINE DON'T TOUCH
+						Dictionary<Pawn, List<Reservation>> reservationClaimantDict = new Dictionary<Pawn, List<Reservation>>();//FINE DON'T TOUCH
 						foreach (Reservation reservation in __instance.reservations)
 						{
 							LocalTargetInfo localTargetInfo = reservation.Target;
 							if (!reservationTargetDict.TryGetValue(localTargetInfo, out List<Reservation> reservationTargetList))
 							{
-								reservationTargetList = new List<Reservation>();
+								reservationTargetList = new List<Reservation>();// DON'T TOUCH
 								reservationTargetDict[localTargetInfo] = reservationTargetList;
 							}
 							reservationTargetList.Add(reservation);
@@ -184,7 +193,7 @@ namespace RimThreaded
 							Pawn claimant = reservation.Claimant;
 							if (!reservationClaimantDict.TryGetValue(claimant, out List<Reservation> reservationClaimantList))
 							{
-								reservationClaimantList = new List<Reservation>();
+								reservationClaimantList = new List<Reservation>();// DON'T TOUCH
 								reservationClaimantDict[claimant] = reservationClaimantList;
 							}
 							reservationClaimantList.Add(reservation);
@@ -209,23 +218,23 @@ namespace RimThreaded
                 if (!reservationClaimantDicts.TryGetValue(__instance, out Dictionary<Pawn, List<Reservation>> reservationClaimantDict2))
                 {
                     Log.Message("RimThreaded is building new Reservations Dictionary...");
-                    Dictionary<LocalTargetInfo, List<Reservation>> reservationTargetDict = new Dictionary<LocalTargetInfo, List<Reservation>>();
-                    reservationClaimantDict = new Dictionary<Pawn, List<Reservation>>();
-                    foreach (Reservation reservation in __instance.reservations)
+                    Dictionary<LocalTargetInfo, List<Reservation>> reservationTargetDict = new Dictionary<LocalTargetInfo, List<Reservation>>();// DON'T TOUCH
+					reservationClaimantDict = new Dictionary<Pawn, List<Reservation>>();// DON'T TOUCH
+					foreach (Reservation reservation in __instance.reservations)
                     {
                         LocalTargetInfo localTargetInfo = reservation.Target;
                         if (!reservationTargetDict.TryGetValue(localTargetInfo, out List<Reservation> reservationTargetList))
                         {
-                            reservationTargetList = new List<Reservation>();
-                            reservationTargetDict[localTargetInfo] = reservationTargetList;
+                            reservationTargetList = new List<Reservation>();// DON'T TOUCH
+							reservationTargetDict[localTargetInfo] = reservationTargetList;
                         }
                         reservationTargetList.Add(reservation);
 
                         Pawn claimant = reservation.Claimant;
                         if (!reservationClaimantDict.TryGetValue(claimant, out List<Reservation> reservationClaimantList))
                         {
-                            reservationClaimantList = new List<Reservation>();
-                            reservationClaimantDict[claimant] = reservationClaimantList;
+                            reservationClaimantList = new List<Reservation>();// DON'T TOUCH
+							reservationClaimantDict[claimant] = reservationClaimantList;
                         }
                         reservationClaimantList.Add(reservation);
                     }
@@ -512,8 +521,17 @@ namespace RimThreaded
 				{
 					if (job.playerForced && __instance.CanReserve(claimant, target, maxPawns, stackCount, layer, true))
 					{
-						reservation = new Reservation(claimant, job, maxPawns, stackCount, target, layer);
-                        List<Reservation> claimantReservations;
+						//reservation = new Reservation(claimant, job, maxPawns, stackCount, target, layer);
+
+						reservation = SimplePool_Patch<Reservation>.Get();//REBUILDING RESERVATION
+						reservation.claimant = claimant;
+						reservation.job = job;
+						reservation.maxPawns = maxPawns;
+						reservation.stackCount = stackCount;
+						reservation.target = target;
+						reservation.layer = layer;//END
+
+						List<Reservation> claimantReservations;
 						
 						reservationTargetDict = getReservationTargetDict(__instance);
 						//newReservationTargetList = new List<Reservation>(getReservationTargetList(reservationTargetDict, target))
@@ -527,7 +545,7 @@ namespace RimThreaded
                         //    {
                         //        reservation
                         //    };
-                        claimantReservations = getReservationClaimantList(reservationClaimantDict, claimant);
+                        claimantReservations = getReservationClaimantList(reservationClaimantDict, claimant, __instance);
                         claimantReservations.Add(reservation);
 
                         foreach (Reservation reservation2 in claimantReservations)
@@ -557,9 +575,16 @@ namespace RimThreaded
 					__result = false;
 					return false;
 				}
-				reservation = new Reservation(claimant, job, maxPawns, stackCount, target, layer);
+				//reservation = new Reservation(claimant, job, maxPawns, stackCount, target, layer);
+				reservation = SimplePool_Patch<Reservation>.Get();//REBUILDING RESERVATION
+				reservation.claimant = claimant;
+				reservation.job = job;
+				reservation.maxPawns = maxPawns;
+				reservation.stackCount = stackCount;
+				reservation.target = target;
+				reservation.layer = layer;//END
 
-                reservationTargetDict = getReservationTargetDict(__instance);
+				reservationTargetDict = getReservationTargetDict(__instance);
 				//newReservationTargetList = new List<Reservation>(getReservationTargetList(reservationTargetDict, target))
 				//	{
 				//		reservation
@@ -570,7 +595,7 @@ namespace RimThreaded
 				//	{
 				//		reservation
 				//	};
-                getReservationClaimantList(reservationClaimantDict, claimant).Add(reservation);
+                getReservationClaimantList(reservationClaimantDict, claimant, __instance).Add(reservation);
 
 			}
 			__result = true;
@@ -600,27 +625,47 @@ namespace RimThreaded
 				lock (__instance)
 				{
 					Dictionary<Pawn, List<Reservation>> reservationClaimantDict = getReservationClaimantDict(__instance);
-					List<Reservation> reservationClaimantList = getReservationClaimantList(reservationClaimantDict, claimant);
-					List<Reservation> newReservationClaimantList = new List<Reservation>();
+					List<Reservation> reservationClaimantList = getReservationClaimantList(reservationClaimantDict, claimant, __instance);
+					//List<Reservation> newReservationClaimantList = new List<Reservation>();
+
+					newReservationClaimantList.Clear();//CHANGES
+
 					foreach (Reservation reservation in reservationClaimantList)
 					{
 						if (reservation != reservation1)
 						{
 							newReservationClaimantList.Add(reservation);
 						}
-						reservationClaimantDict[claimant] = newReservationClaimantList;
+						else
+                        {
+							SimplePool_Patch<Reservation>.Return(reservation);
+						}
+						//reservationClaimantDict[claimant].AddRange(newReservationClaimantList);//?????? this should be outside the foreach?
 					}
+					reservationClaimantDict[claimant].Clear();
+					reservationClaimantDict[claimant].AddRange(newReservationClaimantList);
+
+
 					Dictionary<LocalTargetInfo, List<Reservation>> reservationTargetDict = getReservationTargetDict(__instance);
 					List<Reservation> reservationTargetList = getReservationTargetList(reservationTargetDict, target);
-					List<Reservation> newReservationTargetList = new List<Reservation>();
+
+					//List<Reservation> newReservationTargetList = new List<Reservation>();
+
+					newReservationTargetList.Clear();
+
 					foreach (Reservation reservation2 in reservationTargetList)
 					{
 						if (reservation2 != reservation1)
 						{
 							newReservationTargetList.Add(reservation2);
 						}
+						else
+						{
+							SimplePool_Patch<Reservation>.Return(reservation2);
+						}
 					}
-					reservationTargetDict[target] = newReservationTargetList;					
+					reservationTargetDict[target].Clear();
+					reservationTargetDict[target].AddRange(newReservationTargetList);					
 				}
 			}
 
@@ -647,7 +692,9 @@ namespace RimThreaded
 			lock (__instance)
 			{
 				List<Reservation> reservationTargetList = getReservationTargetList(reservationTargetDict, t.Position);
-				List<Reservation> newReservationTargetList = new List<Reservation>();
+				//List<Reservation> newReservationTargetList = new List<Reservation>();
+
+				newReservationTargetList.Clear();
 				foreach (Reservation reservation in reservationTargetList)
 				{
 					LocalTargetInfo target = reservation.Target;
@@ -658,9 +705,13 @@ namespace RimThreaded
 					}
 					else
 					{
+
 						Dictionary<Pawn, List<Reservation>> reservationClaimantDict = getReservationClaimantDict(__instance);
-						List<Reservation> reservationClaimantList = getReservationClaimantList(reservationClaimantDict, reservation.Claimant);
-						List<Reservation> newReservationClaimantList = new List<Reservation>();
+						List<Reservation> reservationClaimantList = getReservationClaimantList(reservationClaimantDict, reservation.Claimant, __instance);
+						//List<Reservation> newReservationClaimantList = new List<Reservation>();
+
+						newReservationClaimantList.Clear();//CHANGES
+
 						foreach (Reservation reservation2 in reservationClaimantList)
 						{
 							if (reservation2.Target.Thing != t)
@@ -668,7 +719,8 @@ namespace RimThreaded
 								newReservationClaimantList.Add(reservation2);
 							}
 						}
-						reservationClaimantDict[reservation.Claimant] = newReservationTargetList;
+						reservationClaimantDict[reservation.Claimant].Clear();
+						reservationClaimantDict[reservation.Claimant].AddRange(newReservationTargetList);
 
 						//HaulingCache
 						if (thing != null && thing.def.EverHaulable)
@@ -680,8 +732,11 @@ namespace RimThreaded
 							JumboCell.ReregisterObject(__instance.map, plant.Position, RimThreaded.plantHarvest_Cache);
 						}
 
+						SimplePool_Patch<Reservation>.Return(reservation);//RETURN TO POOL
+
 					}
-					reservationTargetDict[t.Position] = newReservationTargetList;
+					reservationTargetDict[t.Position].Clear();
+					reservationTargetDict[t.Position].AddRange(newReservationClaimantList);//was reservationTargetDict[t.Position] should have been created by getReservationTargetList
 				}
 			
 			}
@@ -689,13 +744,16 @@ namespace RimThreaded
 		}
 		public static bool ReleaseClaimedBy(ReservationManager __instance, Pawn claimant, Job job)
 		{
-			Dictionary<Pawn, List<Reservation>> reservationClaimantDict = getReservationClaimantDict(__instance);
+			//Dictionary<Pawn, List<Reservation>> reservationClaimantDict = getReservationClaimantDict(__instance);
 			lock (__instance)
 			{
+				Dictionary<Pawn, List<Reservation>> reservationClaimantDict = getReservationClaimantDict(__instance);
 				Dictionary<LocalTargetInfo, List<Reservation>> reservationTargetDict = getReservationTargetDict(__instance);
-				List<Reservation> reservationClaimantList = getReservationClaimantList(reservationClaimantDict, claimant);
-				List<Reservation> newReservationClaimantList = new List<Reservation>();
-				foreach (Reservation reservation in reservationClaimantList)
+				List<Reservation> reservationClaimantList = getReservationClaimantList(reservationClaimantDict, claimant, __instance);
+				//List<Reservation> newReservationClaimantList = new List<Reservation>();
+
+				newReservationClaimantList.Clear();//CHANGES
+				foreach (Reservation reservation in reservationClaimantList.ToArray())//????????????????????!
 				{
 					if (reservation.Job != job)
 					{
@@ -705,17 +763,19 @@ namespace RimThreaded
 					{
                         LocalTargetInfo target = reservation.Target;
 						List<Reservation> reservationTargetList = getReservationTargetList(reservationTargetDict, target);
-						List<Reservation> newReservationTargetList = new List<Reservation>();
-                        for (int index = 0; index < reservationTargetList.Count; index++)
+						//List<Reservation> newReservationTargetList = new List<Reservation>();
+
+						newReservationTargetList.Clear();
+						for (int index = 0; index < reservationTargetList.Count; index++)
                         {
                             Reservation reservation2 = reservationTargetList[index];
                             if (reservation2.Claimant != claimant || reservation2.Job != job)
                             {
-                                newReservationTargetList.Add(reservation2);
+								newReservationTargetList.Add(reservation2);
                             }
                         }
-
-                        reservationTargetDict[target] = newReservationTargetList;
+						reservationTargetDict[target].Clear();
+						reservationTargetDict[target].AddRange(newReservationTargetList);
 						//HaulingCache
 						Thing thing = target.Thing;
 						if (thing != null && thing.def.EverHaulable)
@@ -727,8 +787,11 @@ namespace RimThreaded
 							JumboCell.ReregisterObject(__instance.map, plant.Position, RimThreaded.plantHarvest_Cache);
 						}
 
+						SimplePool_Patch<Reservation>.Return(reservation);//RETURN TO POOL
+
 					}
-					reservationClaimantDict[claimant] = newReservationClaimantList;
+					reservationClaimantDict[claimant].Clear();
+					reservationClaimantDict[claimant].AddRange(newReservationClaimantList);
 				}
 			}
 			return false;
@@ -740,22 +803,28 @@ namespace RimThreaded
 			lock (__instance)
 			{
 				Dictionary<LocalTargetInfo, List<Reservation>> reservationTargetDict = getReservationTargetDict(__instance);
-				List<Reservation> reservationClaimantList = getReservationClaimantList(reservationClaimantDict, claimant);
+				List<Reservation> reservationClaimantList = getReservationClaimantList(reservationClaimantDict, claimant, __instance);
 				foreach (Reservation reservation in reservationClaimantList)
 				{
 					LocalTargetInfo target = reservation.Target;
 					List<Reservation> reservationTargetList = getReservationTargetList(reservationTargetDict, target);
-					List<Reservation> newReservationTargetList = new List<Reservation>();
-                    for (int index = 0; index < reservationTargetList.Count; index++)
+					//List<Reservation> newReservationTargetList = new List<Reservation>();
+
+					newReservationTargetList.Clear();
+					for (int index = 0; index < reservationTargetList.Count; index++)
                     {
                         Reservation reservation2 = reservationTargetList[index];
                         if (reservation2.Claimant != claimant)
                         {
-                            newReservationTargetList.Add(reservation2);
+							newReservationTargetList.Add(reservation2);
                         }
+						else
+                        {
+							SimplePool_Patch<Reservation>.Return(reservation);//RETURN TO POOL
+						}
                     }
-
-                    reservationTargetDict[target] = newReservationTargetList;
+					reservationTargetDict[target].Clear();
+					reservationTargetDict[target].AddRange(newReservationTargetList);
 					//HaulingCache
 					Thing thing = target.Thing;
 					if (thing != null && thing.def.EverHaulable)
@@ -768,7 +837,8 @@ namespace RimThreaded
 					}
 
 				}
-				reservationClaimantDict[claimant] = new List<Reservation>();
+				//reservationClaimantDict[claimant] = new List<Reservation>();//why not just clearing?
+				reservationClaimantDict[claimant].Clear(); // doubts about this one maybe there was a reason for doing a new list here?
 			}
 			return false;
 		}

--- a/Source/RimThreaded.cs
+++ b/Source/RimThreaded.cs
@@ -220,7 +220,7 @@ namespace RimThreaded
             World_Patch.InitializeThreadStatics();
             WorldPawns_Patch.InitializeThreadStatics();
             AttackTargetReservationManager_Patch.InitializeThreadStatics();
-            ReservationManager_Patch.InitializeThreadStatics();
+            //ReservationManager_Patch.InitializeThreadStatics();
         }
         private static void ProcessTicks(ThreadInfo threadInfo)
         {

--- a/Source/RimThreaded.cs
+++ b/Source/RimThreaded.cs
@@ -220,6 +220,7 @@ namespace RimThreaded
             World_Patch.InitializeThreadStatics();
             WorldPawns_Patch.InitializeThreadStatics();
             AttackTargetReservationManager_Patch.InitializeThreadStatics();
+            ReservationManager_Patch.InitializeThreadStatics();
         }
         private static void ProcessTicks(ThreadInfo threadInfo)
         {

--- a/Source/RimThreaded.cs
+++ b/Source/RimThreaded.cs
@@ -76,7 +76,7 @@ namespace RimThreaded
         public static HashSet<int> initializedThreads = new HashSet<int>();
 
         public static object allSustainersLock = new object();
-        public static object map_AttackTargetReservationManager_reservations_Lock = new object();
+        //public static object map_AttackTargetReservationManager_reservations_Lock = new object();
 
 
         public class ThreadInfo
@@ -219,6 +219,7 @@ namespace RimThreaded
             Toils_Ingest_Patch.InitializeThreadStatics();
             World_Patch.InitializeThreadStatics();
             WorldPawns_Patch.InitializeThreadStatics();
+            AttackTargetReservationManager_Patch.InitializeThreadStatics();
         }
         private static void ProcessTicks(ThreadInfo threadInfo)
         {
@@ -389,7 +390,7 @@ namespace RimThreaded
                     tickList.preparing = -1;
                     tickList.threadCount = -1;
                 }
-
+                //OneTickPools Ticks go here.
                 listsFullyProcessed = 0;
                 workingOnDateNotifierTick = -1;
                 workingOnWorldTick = -1;


### PR DESCRIPTION
Rebuilt the AttackTargetReservationManager to not create new templists and recycle reservations (fu gc).
Also fixed a ticking exception with the AutoSlaughterManager.