### PR TITLE
2.5.15

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,17 @@ DONATE:
 Some subscribers insisted that I set up a donation page. For those looking, here it is: https://ko-fi.com/rimthreaded  
 
 CHANGE LOG:  
+Version 2.5.15 - Sith Memory Rub   
+-Fixed bug in RecordWorker_TimeGettingJoy  
+-Fixed bug in HediffSet.AddDirect  
+-Fixed bug in MemoryThoughtHandler.TryGainMemory  
+-Fixed bug in Pawn_HealthTracker.CheckForStateChange  
+-Fixed bug in Pawn_HealthTracker.PostApplyDamage  
+-Fixed bug in SituationalThoughtHandler.RemoveExpiredThoughtsFromCache  
+-Lowered Transpile Harmony priority for RT methods  
+-Removed disablelimits in RT settings  
+-Transpiled Thing.TakeDamage  
+
 Version 2.5.14 - First Intergalactic War  
 -Added better ReplaceStuff Compatibility  
 -Added better RimWar Compatibility  

--- a/RimThreaded/About/About.xml
+++ b/RimThreaded/About/About.xml
@@ -11,15 +11,16 @@
   <description>
     RimThreaded enables RimWorld to utilize multiple threads and thus greatly increases the speed of the game.
 
-    Version 2.5.14 - First Intergalactic War  
-    -Added better ReplaceStuff Compatibility  
-    -Added better RimWar Compatibility  
-    -Added better JobsOfOppurtunity Compatibility  
-    -Fixed bug in Hauling  
-    -Fixed bug in RimWorld.Planet.TileFinder  
-    -Fixed bugs in Verse.PawnTextureAtlas  
-    -Fixed bug in Pawn_RotationTracker.UpdateRotation  
-    -Fixed ReplacementField Assembly Caches doubling work 
+    Version 2.5.15 - Sith Memory Rub
+    -Fixed bug in RecordWorker_TimeGettingJoy
+    -Fixed bug in HediffSet.AddDirect
+    -Fixed bug in MemoryThoughtHandler.TryGainMemory
+    -Fixed bug in Pawn_HealthTracker.CheckForStateChange
+    -Fixed bug in Pawn_HealthTracker.PostApplyDamage
+    -Fixed bug in SituationalThoughtHandler.RemoveExpiredThoughtsFromCache
+    -Lowered Transpile Harmony priority for RT methods
+    -Removed disablelimits in RT settings
+    -Transpiled Thing.TakeDamage
 
     RimThreaded enables RimWorld to utilize multiple threads and thus greatly increases the speed of the game.
 

--- a/RimThreaded/About/About.xml
+++ b/RimThreaded/About/About.xml
@@ -24,24 +24,11 @@
 
     RimThreaded enables RimWorld to utilize multiple threads and thus greatly increases the speed of the game.
 
-    JOIN OUR COMMUNITY ON DISCORD:
+    JOIN OUR COMMUNITY ON DISCORD / SUBMIT BUGS:
     https://discord.gg/3JJuWK8
 
-    WIKI:
-    https://github.com/cseelhoff/RimThreaded/wiki
-
-    MOD COMPATIBILITY:
-    https://github.com/cseelhoff/RimThreaded/wiki/Mod-Compatibility
-
-    SETTINGS:
-    The number of threads to utilize should be set in the mod settings, according to your specific computer's core count.
-    If you are expiriencing "Thread Timeout" errors, try increasing your Thread Abort Timeout threshold.
-
-    LOAD ORDER:
-    Put RimThreaded last in load order.
-
-    SUBMIT BUGS:
-    https://github.com/cseelhoff/RimThreaded/issues/new/choose
+    MOD COMPATIBILITY/LOAD ORDER:
+    Use RimPy to check mod compatibility and load order
 
     CREDITS:
     Big thanks to Sernior for his continued help bug fixing and performance tweaks!
@@ -49,7 +36,7 @@
     Big thanks to Brrainz (Pardeike) for Harmony and all of the coding help!
     Big thanks to Kiame Vivacity for his help with fixing sound!
     Special thank you for helping me test Austin (Stanui)!
-    Thank you bookdude13 for your many bugfixes!
+    Thank you bookdude13 for your many bug fixes!
     Thank you to Ataman for helping me fix the LVM deep storage bug!
     Thank you Ken for fixing RegionCostCalculator.PathableNeighborIndices!
     Thank you Raccoononi for the RT 2.0 logo! https://discordhub.com/profile/245738467995156481

--- a/RimThreaded/About/About.xml
+++ b/RimThreaded/About/About.xml
@@ -22,8 +22,6 @@
     -Removed disablelimits in RT settings
     -Transpiled Thing.TakeDamage
 
-    RimThreaded enables RimWorld to utilize multiple threads and thus greatly increases the speed of the game.
-
     JOIN OUR COMMUNITY ON DISCORD / SUBMIT BUGS:
     https://discord.gg/3JJuWK8
 

--- a/Source/HediffSet_Patch.cs
+++ b/Source/HediffSet_Patch.cs
@@ -173,15 +173,12 @@ namespace RimThreaded
 
                 if (!flag)
                 {
-                    //List<Hediff> newHediffs = new List<Hediff>(__instance.hediffs) { hediff };
-                    //__instance.hediffs = newHediffs;
-                    __instance.hediffs.Add(hediff);
+                    List<Hediff> newHediffs = new List<Hediff>(__instance.hediffs) { hediff };
+                    __instance.hediffs = newHediffs;
+                    //__instance.hediffs.Add(hediff);
 
                     hediff.PostAdd(dinfo);
-                    if (__instance.pawn.needs != null && __instance.pawn.needs.mood != null)
-                    {
-                        __instance.pawn.needs.mood.thoughts.situational.Notify_SituationalThoughtsDirty();
-                    }
+                    __instance.pawn.needs?.mood?.thoughts.situational.Notify_SituationalThoughtsDirty();
                 }
             }
             bool flag2 = hediff is Hediff_MissingPart;

--- a/Source/Mod_Patches/SpeakUp_Patch.cs
+++ b/Source/Mod_Patches/SpeakUp_Patch.cs
@@ -16,7 +16,7 @@ namespace RimThreaded.Mod_Patches
             SpeakUp_GrammarResolver_Resolve = TypeByName("SpeakUp.GrammarResolver_Resolve");
             if (SpeakUp_GrammarResolver_Resolve != null)
             {
-                string methodName = nameof(Prefix);
+                //string methodName = nameof(Prefix);
                 //Log.Message("RimThreaded is patching " + SpeakUp_GrammarResolver_Resolve.FullName + " " + methodName);
                 //Transpile(SpeakUp_GrammarResolver_Resolve, typeof(SpeakUp_Patch), methodName);
             }

--- a/Source/RecordWorker_TimeGettingJoy_Patch.cs
+++ b/Source/RecordWorker_TimeGettingJoy_Patch.cs
@@ -1,0 +1,21 @@
+﻿using RimWorld;
+using System;
+using Verse;
+
+namespace RimThreaded
+{
+    class RecordWorker_TimeGettingJoy_Patch
+    {
+        public static void RunDestructivePatches()
+        {
+            Type original = typeof(RecordWorker_TimeGettingJoy);
+            Type patched = typeof(RecordWorker_TimeGettingJoy_Patch);
+            RimThreadedHarmony.Prefix(original, patched, nameof(ShouldMeasureTimeNow));
+        }
+        public static bool ShouldMeasureTimeNow(RecordWorker_TimeGettingJoy __instance, ref bool __result, Pawn pawn)
+        {
+            __result = pawn?.CurJob?.def?.joyKind != null;
+            return false;
+        }
+	}
+}

--- a/Source/RimThreaded.cs
+++ b/Source/RimThreaded.cs
@@ -439,6 +439,8 @@ namespace RimThreaded
         }
 
         public static int frameCount = 0;
+        public static TimeSpan halfTimeoutMS = new TimeSpan(0,0,0,0,4000);
+
         public static void MainThreadWaitLoop(TickManager tickManager)
         {
             frameCount = Time.frameCount;

--- a/Source/RimThreaded.csproj
+++ b/Source/RimThreaded.csproj
@@ -11,15 +11,15 @@
     <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <TargetFramework>net472</TargetFramework>
-		<Version>2.5.14</Version>
+		<Version>2.5.15</Version>
 		<Copyright>Copyright ©  2021</Copyright>
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
-    <AssemblyVersion>2.5.14.0</AssemblyVersion>
+    <AssemblyVersion>2.5.15.0</AssemblyVersion>
     <Authors>Caleb Seelhoff</Authors>
-    <FileVersion>2.5.14.0</FileVersion>
+    <FileVersion>2.5.15.0</FileVersion>
     <Configurations>DB12;Rel12;DB13;Rel13</Configurations>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'DB13|AnyCPU' ">

--- a/Source/RimThreadedHarmony.cs
+++ b/Source/RimThreadedHarmony.cs
@@ -744,11 +744,11 @@ namespace RimThreaded
 			harmony.Patch(oMethod, postfix: new HarmonyMethod(pMethod));
 		}
 
-		public static void Transpile(Type original, Type patched, string methodName, Type[] origType = null, string[] harmonyAfter = null)
+		public static void Transpile(Type original, Type patched, string methodName, Type[] origType = null, string[] harmonyAfter = null, int priority = 0)
 		{
 			MethodInfo oMethod = Method(original, methodName, origType);
 			MethodInfo pMethod = Method(patched, methodName);
-			HarmonyMethod transpilerMethod = new HarmonyMethod(pMethod)
+			HarmonyMethod transpilerMethod = new HarmonyMethod(pMethod, priority)
 			{
 				after = harmonyAfter
 			};

--- a/Source/RimThreadedHarmony.cs
+++ b/Source/RimThreadedHarmony.cs
@@ -918,6 +918,7 @@ namespace RimThreaded
 			ReachabilityCache_Patch.RunDestructivePatches(); //TODO simplfy instance.fields
 			RealtimeMoteList_Patch.RunDestructivePatches();
 			RecipeWorkerCounter_Patch.RunDestructivePatches(); // rexamine purpose
+            RecordWorker_TimeGettingJoy_Patch.RunDestructivePatches();
 			RegionAndRoomUpdater_Patch.RunDestructivePatches();
 			RegionDirtyer_Patch.RunDestructivePatches();
 			RegionGrid_Patch.RunDestructivePatches();

--- a/Source/RimThreadedMod.cs
+++ b/Source/RimThreadedMod.cs
@@ -42,10 +42,11 @@ namespace RimThreaded
             Settings.DoWindowContents(inRect);
             if (Settings.maxThreads != RimThreaded.maxThreads)
             {
-                RimThreaded.maxThreads = Settings.disablelimits ? Math.Max(Settings.maxThreads, 1) : Math.Min(Math.Max(Settings.maxThreads, 1), 255);
+                RimThreaded.maxThreads = Math.Max(Settings.maxThreads, 1);
                 RimThreaded.RestartAllWorkerThreads();
             }
-            RimThreaded.timeoutMS = Settings.disablelimits ? Math.Max(Settings.timeoutMS, 1) : Math.Min(Math.Max(Settings.timeoutMS, 10000), 1000000);
+            RimThreaded.timeoutMS = Math.Max(Settings.timeoutMS, 1000);
+            RimThreaded.halfTimeoutMS = new TimeSpan(0,0,0,0,RimThreaded.timeoutMS / 2);
             RimThreaded.timeSpeedNormal = Settings.timeSpeedNormal;
             RimThreaded.timeSpeedFast = Settings.timeSpeedFast;
             RimThreaded.timeSpeedSuperfast = Settings.timeSpeedSuperfast;

--- a/Source/RimThreadedSettings.cs
+++ b/Source/RimThreadedSettings.cs
@@ -19,7 +19,6 @@ namespace RimThreaded
         public float timeSpeedUltrafast = 150f;
         public string timeSpeedUltrafastBuffer = "150";
         public bool disablesomealerts = false;
-        public bool disablelimits = false;
         public bool disableforcedslowdowns = false;
         public float scrollViewHeight;
         public Vector2 scrollPosition;

--- a/Source/SituationalThoughtHandler_Patch.cs
+++ b/Source/SituationalThoughtHandler_Patch.cs
@@ -160,11 +160,50 @@ namespace RimThreaded
             lock (__instance)
             {
                 Dictionary<Pawn, CachedSocialThoughts> newCachedSocialThoughts = new Dictionary<Pawn, CachedSocialThoughts>(__instance.cachedSocialThoughts);
-                newCachedSocialThoughts.RemoveAll(x => x.Value.Expired || x.Key.Discarded);
+                RemoveAll(newCachedSocialThoughts, x => x.Value.Expired || x.Key.Discarded);
                 __instance.cachedSocialThoughts = newCachedSocialThoughts;
             }
             return false;
         }
+        public static int RemoveAll<Pawn, CachedSocialThoughts>(Dictionary<Pawn, CachedSocialThoughts> dictionary, Predicate<KeyValuePair<Pawn, CachedSocialThoughts>> predicate)
+        {
+            List<Pawn> list = null;
+            try
+            {
+                foreach (KeyValuePair<Pawn, CachedSocialThoughts> item in dictionary)
+                {
+                    if (predicate(item))
+                    {
+                        if (list == null)
+                        {
+                            list = SimplePool<List<Pawn>>.Get();
+                        }
 
+                        list.Add(item.Key);
+                    }
+                }
+
+                if (list != null)
+                {
+                    int i = 0;
+                    for (int count = list.Count; i < count; i++)
+                    {
+                        dictionary.Remove(list[i]);
+                    }
+
+                    return list.Count;
+                }
+
+                return 0;
+            }
+            finally
+            {
+                if (list != null)
+                {
+                    list.Clear();
+                    SimplePool<List<Pawn>>.Return(list);
+                }
+            }
+        }
     }
 }

--- a/Source/Thing_Patch.cs
+++ b/Source/Thing_Patch.cs
@@ -1,151 +1,47 @@
 ﻿using RimWorld;
 using System;
 using System.Collections.Generic;
-using UnityEngine;
+using System.Linq;
+using System.Reflection;
+using System.Reflection.Emit;
+using HarmonyLib;
 using Verse;
+using static HarmonyLib.AccessTools;
 
 namespace RimThreaded
 {
     class Thing_Patch
     {
-        public static Dictionary<Thing, sbyte> lastMapIndex = new Dictionary<Thing, sbyte>();
         internal static void RunDestructivePatches()
         {
             Type original = typeof(Thing);
             Type patched = typeof(Thing_Patch);
             RimThreadedHarmony.Prefix(original, patched, nameof(get_Map));
-            RimThreadedHarmony.Prefix(original, patched, nameof(TakeDamage)); //good candidate for transpile
-            //RimThreadedHarmony.Postfix(original, patched, nameof(SpawnSetup));
-            //RimThreadedHarmony.Postfix(original, patched, nameof(DeSpawn));
-            //RimThreadedHarmony.Prefix(original, patched, nameof(TakeDamage));
-        }
-
-        //good candidate for transpile
-        public static bool TakeDamage(Thing __instance, ref DamageWorker.DamageResult __result, DamageInfo dinfo)
-        {
-            if (__instance.Destroyed)
-            {
-                __result = new DamageWorker.DamageResult();
-                return false;
-            }
-            if ((double)dinfo.Amount == 0.0)
-            {
-                __result = new DamageWorker.DamageResult();
-                return false;
-            }
-            if (__instance.def.damageMultipliers != null)
-            {
-                for (int index = 0; index < __instance.def.damageMultipliers.Count; ++index)
-                {
-                    if (__instance.def.damageMultipliers[index].damageDef == dinfo.Def)
-                    {
-                        int num = Mathf.RoundToInt(dinfo.Amount * __instance.def.damageMultipliers[index].multiplier);
-                        dinfo.SetAmount((float)num);
-                    }
-                }
-            }
-            bool absorbed;
-            __instance.PreApplyDamage(ref dinfo, out absorbed);
-            if (absorbed)
-            {
-                __result = new DamageWorker.DamageResult();
-                return false;
-            }
-            bool anyParentSpawned = __instance.SpawnedOrAnyParentSpawned;
-
-            Map mapHeld = __instance.MapHeld;
-            DamageWorker.DamageResult damageResult = dinfo.Def.Worker.Apply(dinfo, __instance);            
-            if (mapHeld != null && dinfo.Def.harmsHealth & anyParentSpawned) // added mapHeld null check
-                mapHeld.damageWatcher.Notify_DamageTaken(__instance, damageResult.totalDamageDealt);
-            if (dinfo.Def.ExternalViolenceFor(__instance))
-            {
-#if RW13
-                if (dinfo.SpawnFilth)
-#endif
-                GenLeaving.DropFilthDueToDamage(__instance, damageResult.totalDamageDealt);
-                if (dinfo.Instigator != null && dinfo.Instigator is Pawn instigator2)
-                {
-                    if (instigator2 != null)
-                    {
-                        instigator2.records.AddTo(RecordDefOf.DamageDealt, damageResult.totalDamageDealt);
-#if RW12
-                        instigator2.records.AccumulateStoryEvent(StoryEventDefOf.DamageDealt);
-#endif
-                    }
-                }
-            }
-            __instance.PostApplyDamage(dinfo, damageResult.totalDamageDealt);
-            __result = damageResult;
-            return false;
+            RimThreadedHarmony.Transpile(original, patched, nameof(TakeDamage));
         }
         
-        //public static bool DeSpawn(Thing __instance, DestroyMode mode = DestroyMode.Vanish)
-        //{
-        //    if (__instance.Destroyed)
-        //        Log.Error("Tried to despawn " + __instance.ToStringSafe<Thing>() + " which is already destroyed.");
-        //    else if (!__instance.Spawned)
-        //    {
-        //        Log.Error("Tried to despawn " + __instance.ToStringSafe<Thing>() + " which is not spawned.");
-        //    }
-        //    else
-        //    {
-        //        Map map = __instance.Map;
-        //        map.overlayDrawer.DisposeHandle(__instance);
-        //        RegionListersUpdater.DeregisterInRegions(__instance, map);
-        //        ThingOwner newSpawnedThings = map.spawnedThings;
-        //        map.spawnedThings.Remove(__instance);
-        //        map.listerThings.Remove(__instance);
-        //        map.thingGrid.Deregister(__instance);
-        //        map.coverGrid.DeRegister(__instance);
-        //        if (__instance.def.receivesSignals)
-        //            Find.SignalManager.DeregisterReceiver((ISignalReceiver)__instance);
-        //        map.tooltipGiverList.Notify_ThingDespawned(__instance);
-        //        if (__instance.def.CanAffectLinker)
-        //        {
-        //            map.linkGrid.Notify_LinkerCreatedOrDestroyed(__instance);
-        //            map.mapDrawer.MapMeshDirty(__instance.Position, MapMeshFlag.Things, true, false);
-        //        }
-        //        if (Find.Selector.IsSelected((object)__instance))
-        //        {
-        //            Find.Selector.Deselect((object)__instance);
-        //            Find.MainButtonsRoot.tabs.Notify_SelectedObjectDespawned();
-        //        }
-        //        __instance.DirtyMapMesh(map);
-        //        if (__instance.def.drawerType != DrawerType.MapMeshOnly)
-        //            map.dynamicDrawManager.DeRegisterDrawable(__instance);
-        //        Region regionAtNoRebuild = map.regionGrid.GetValidRegionAt_NoRebuild(__instance.Position);
-        //        (regionAtNoRebuild == null ? (Room)null : regionAtNoRebuild.Room)?.Notify_ContainedThingSpawnedOrDespawned(__instance);
-        //        if (__instance.def.AffectsRegions)
-        //            map.regionDirtyer.Notify_ThingAffectingRegionsDespawned(__instance);
-        //        if (__instance.def.pathCost != 0 || __instance.def.passability == Traversability.Impassable)
-        //            map.pathing.RecalculatePerceivedPathCostUnderThing(__instance);
-        //        if (__instance.def.AffectsReachability)
-        //            map.reachability.ClearCache();
-        //        Find.TickManager.DeRegisterAllTickabilityFor(__instance);
-        //        __instance.mapIndexOrState = (sbyte)-1;
-        //        if (__instance.def.category == ThingCategory.Item)
-        //        {
-        //            map.listerHaulables.Notify_DeSpawned(__instance);
-        //            map.listerMergeables.Notify_DeSpawned(__instance);
-        //        }
-        //        map.attackTargetsCache.Notify_ThingDespawned(__instance);
-        //        map.physicalInteractionReservationManager.ReleaseAllForTarget((LocalTargetInfo)__instance);
-        //        StealAIDebugDrawer.Notify_ThingChanged(__instance);
-        //        if (__instance is IHaulDestination haulDestination3)
-        //            map.haulDestinationManager.RemoveHaulDestination(haulDestination3);
-        //        if (__instance is IThingHolder && Find.ColonistBar != null)
-        //            Find.ColonistBar.MarkColonistsDirty();
-        //        if (__instance.def.category == ThingCategory.Item)
-        //        {
-        //            SlotGroup slotGroup = __instance.Position.GetSlotGroup(map);
-        //            if (slotGroup != null && slotGroup.parent != null)
-        //                slotGroup.parent.Notify_LostThing(__instance);
-        //        }
-        //        QuestUtility.SendQuestTargetSignals(__instance.questTags, "Despawned", __instance.Named("SUBJECT"));
-        //    }
-        //    return false;
-        //}
-
+        public static IEnumerable<CodeInstruction> TakeDamage(IEnumerable<CodeInstruction> instructions,
+            ILGenerator iLGenerator)
+        {
+            List<CodeInstruction> instructionsList = instructions.ToList();
+            for (int i = 0; i < instructionsList.Count; i++)
+            {
+                CodeInstruction ci = instructionsList[i];
+                if (ci.opcode == OpCodes.Call && (MethodInfo) ci.operand == Method(typeof(Map), "get_MapHeld"))
+                {
+                    yield return instructionsList[i++];
+                    yield return instructionsList[i];
+                    yield return new CodeInstruction(OpCodes.Ldloc_2);
+                    Label label = (Label) instructionsList[i + 13].operand;
+                    yield return new CodeInstruction(OpCodes.Brfalse, label);
+                }
+                else
+                {
+                    yield return ci;
+                }
+            }
+        }
+        
         public static bool get_Map(Thing __instance, ref Map __result)
         {
             __result = null;
@@ -164,17 +60,7 @@ namespace RimThreaded
             //}
             return false;
         }
-
-        public static void SpawnSetup(Thing __instance, Map map, bool respawningAfterLoad)
-        {
-            if (__instance.mapIndexOrState >= 0)
-            {
-                lock (lastMapIndex)
-                {
-                    lastMapIndex[__instance] = __instance.mapIndexOrState;
-                }
-            }
-        }
+        
 
     }
 }


### PR DESCRIPTION
Version 2.5.15 - Sith Memory Rub
-Fixed bug in RecordWorker_TimeGettingJoy
-Fixed bug in HediffSet.AddDirect
-Fixed bug in MemoryThoughtHandler.TryGainMemory
-Fixed bug in Pawn_HealthTracker.CheckForStateChange
-Fixed bug in Pawn_HealthTracker.PostApplyDamage
-Fixed bug in SituationalThoughtHandler.RemoveExpiredThoughtsFromCache
-Lowered Transpile Harmony priority for RT methods
-Removed disablelimits in RT settings
-Transpiled Thing.TakeDamage