### PR TITLE
Fixed SOS2 Vacuum check being a giant race condition. + Reservation Manager Rebuilt and fixed.

### DIFF
--- a/Source/District_Patch.cs
+++ b/Source/District_Patch.cs
@@ -61,7 +61,7 @@ namespace RimThreaded
                 __instance.cachedCellCount = -1;
                 __instance.cachedOpenRoofCount = -1;
                 __instance.cachedOpenRoofState = null;
-                AnimalPenConnectedDistrictsCalculator.InvalidateDistrictCache(__instance);
+                //AnimalPenConnectedDistrictsCalculator.InvalidateDistrictCache(__instance);
                 __instance.lastChangeTick = Find.TickManager.TicksGame;
                 FacilitiesUtility.NotifyFacilitiesAboutChangedLOSBlockers(__instance.regions);
             }

--- a/Source/District_Patch.cs
+++ b/Source/District_Patch.cs
@@ -61,6 +61,7 @@ namespace RimThreaded
                 __instance.cachedCellCount = -1;
                 __instance.cachedOpenRoofCount = -1;
                 __instance.cachedOpenRoofState = null;
+                AnimalPenConnectedDistrictsCalculator.InvalidateDistrictCache(__instance);
                 __instance.lastChangeTick = Find.TickManager.TicksGame;
                 FacilitiesUtility.NotifyFacilitiesAboutChangedLOSBlockers(__instance.regions);
             }

--- a/Source/GridsUtility_Patch.cs
+++ b/Source/GridsUtility_Patch.cs
@@ -11,6 +11,7 @@ namespace RimThreaded
             Type original = typeof(GridsUtility);
             Type patched = typeof(GridsUtility_Patch);
             RimThreadedHarmony.Prefix(original, patched, nameof(Fogged), new Type[] { typeof(Thing) });
+            RimThreadedHarmony.Prefix(original, patched, nameof(Fogged), new Type[] { typeof(IntVec3), typeof(Map) });
             RimThreadedHarmony.Prefix(original, patched, nameof(GetThingList));
             RimThreadedHarmony.Prefix(original, patched, nameof(GetEdifice));
         }
@@ -35,6 +36,23 @@ namespace RimThreaded
             if (thingGrid == null)
                 return false;
             __result = thingGrid.ThingsListAt(c);
+            return false;
+        }
+        /*public static bool Fogged(this IntVec3 c, Map map)
+        {
+            return map.fogGrid.IsFogged(c);
+        }*/
+        public static bool Fogged(ref bool __result, IntVec3 c, Map map)
+        {
+            __result = false;
+            if (c == null)
+                return false;
+            if (map == null)
+                return false;
+            FogGrid fogGrid = map.fogGrid;
+            if (fogGrid == null)
+                return false;
+            __result = fogGrid.IsFogged(c);
             return false;
         }
 

--- a/Source/Mod_Patches/SOS2_Patch.cs
+++ b/Source/Mod_Patches/SOS2_Patch.cs
@@ -1,0 +1,97 @@
+﻿using HarmonyLib;
+using System;
+using System.Reflection;
+using Verse;
+using System.Collections.Generic;
+using System.Reflection.Emit;
+using static HarmonyLib.AccessTools;
+using static RimThreaded.RimThreadedHarmony;
+
+namespace RimThreaded.Mod_Patches
+{
+    class SOS2_Patch
+    {
+        public static void Patch()
+        {
+            Type ShipInteriorMod2 = TypeByName("SaveOurShip2.ShipInteriorMod2");
+            if (ShipInteriorMod2 != null)
+            {
+                string methodName = nameof(hasSpaceSuit);
+                Log.Message("RimThreaded is patching " + ShipInteriorMod2.FullName + " " + methodName);
+                Transpile(ShipInteriorMod2, typeof(SOS2_Patch), methodName);
+            }
+            Type ApparelTracker_Notify_Added = TypeByName("SaveOurShip2.ShipInteriorMod2+ApparelTracker_Notify_Added");//+for nested classes
+            if (ApparelTracker_Notify_Added != null)
+            {
+                string methodName = nameof(Postfix);
+                Log.Message("RimThreaded is patching " + ApparelTracker_Notify_Added.FullName + " " + methodName);
+                Transpile(ApparelTracker_Notify_Added, typeof(SOS2_Patch), methodName);
+            }
+            Type ApparelTracker_Notify_Removed = TypeByName("SaveOurShip2.ShipInteriorMod2+ApparelTracker_Notify_Removed");//+for nested classes
+            if (ApparelTracker_Notify_Removed != null)
+            {
+                string methodName = nameof(Postfix);
+                Log.Message("RimThreaded is patching " + ApparelTracker_Notify_Removed.FullName + " " + methodName);
+                Transpile(ApparelTracker_Notify_Removed, typeof(SOS2_Patch), methodName);
+            }
+        }
+
+        public static void Add(Dictionary<int, Tuple<int, bool>> _cache_spacesuit, int i, Tuple<int, bool> t)
+        {
+            lock (_cache_spacesuit)
+            {
+                _cache_spacesuit[i] = t;
+            }
+        }
+        public static bool TryGetValue(Dictionary<int, Tuple<int, bool>> _cache_spacesuit, int i, out Tuple<int, bool> t)
+        {
+            lock (_cache_spacesuit)
+            {
+                return _cache_spacesuit.TryGetValue(i, out t);
+            }
+        }
+        public static int RemoveAll(Dictionary<int, Tuple<int, bool>> _cache_spacesuit, Predicate<KeyValuePair<int, Tuple<int,bool>>> p)
+        {
+            lock (_cache_spacesuit)
+            {
+                return _cache_spacesuit.RemoveAll(p);
+            }
+        }
+
+        public static IEnumerable<CodeInstruction> hasSpaceSuit(IEnumerable<CodeInstruction> instructions, ILGenerator iLGenerator)
+        {
+            Type _cache_spacesuit = typeof(Dictionary<int, Tuple<int, bool>>);
+            foreach (CodeInstruction i in instructions)
+            {
+                if (i.opcode == OpCodes.Callvirt)
+                {
+                    if ((MethodInfo)i.operand == Method(_cache_spacesuit, "set_Item"))
+                    {
+                        i.operand = Method(typeof(SOS2_Patch), nameof(Add));
+                    }
+                    if ((MethodInfo)i.operand == Method(_cache_spacesuit, "TryGetValue"))
+                    {
+                        i.operand = Method(typeof(SOS2_Patch), nameof(TryGetValue));
+                    }
+                }
+                yield return i;
+            }
+        }
+
+        public static IEnumerable<CodeInstruction> Postfix(IEnumerable<CodeInstruction> instructions, ILGenerator iLGenerator)
+        {
+            Type _cache_spacesuit = typeof(Dictionary<int, Tuple<int, bool>>);
+            foreach (CodeInstruction i in instructions)
+            {
+                if (i.opcode == OpCodes.Call)
+                {
+                    if ((MethodInfo)i.operand == Method(_cache_spacesuit, "RemoveAll"))
+                    {
+                        i.operand = Method(typeof(SOS2_Patch), nameof(RemoveAll));
+                    }
+                }
+                yield return i;
+            }
+        }
+    }
+}

--- a/Source/Mod_Patches/SOS2_Patch.cs
+++ b/Source/Mod_Patches/SOS2_Patch.cs
@@ -81,11 +81,12 @@ namespace RimThreaded.Mod_Patches
         public static IEnumerable<CodeInstruction> Postfix(IEnumerable<CodeInstruction> instructions, ILGenerator iLGenerator)
         {
             Type _cache_spacesuit = typeof(Dictionary<int, Tuple<int, bool>>);
+            Type GenCollection = typeof(Verse.GenCollection);
             foreach (CodeInstruction i in instructions)
             {
                 if (i.opcode == OpCodes.Call)
                 {
-                    if ((MethodInfo)i.operand == Method(_cache_spacesuit, "RemoveAll"))
+                    if ((MethodInfo)i.operand == Method(GenCollection, "RemoveAll", new Type[] { typeof(Dictionary<int, Tuple<int, bool>>), typeof(Predicate<KeyValuePair<int, Tuple<int, bool>>>) }, new Type[] { typeof(int), typeof(Tuple<int, bool>) }))
                     {
                         i.operand = Method(typeof(SOS2_Patch), nameof(RemoveAll));
                     }

--- a/Source/Mod_Patches/VEE_Patch.cs
+++ b/Source/Mod_Patches/VEE_Patch.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Reflection.Emit;
 using static HarmonyLib.AccessTools;
 using static RimThreaded.RimThreadedHarmony;
+using RimWorld;
 
 namespace RimThreaded.Mod_Patches
 {
@@ -34,6 +35,13 @@ namespace RimThreaded.Mod_Patches
                 Log.Message("RimThreaded is patching " + VEE_Plant_TickLong.FullName + " " + methodName);
                 Transpile(VEE_Plant_TickLong, typeof(VEE_Patch), methodName);
             }
+            Type MapComp_Drought = TypeByName("VEE.MapComp_Drought");
+            if (MapComp_Drought != null)
+            {
+                string methodName = nameof(MapComponentTick);
+                Log.Message("RimThreaded is patching " + MapComp_Drought.FullName + " " + methodName);
+                Transpile(MapComp_Drought, typeof(VEE_Patch), methodName);
+            }
         }
         
         public static bool ContainsKey(Dictionary<Map, object> MapComp_Drought, Map m)
@@ -43,6 +51,20 @@ namespace RimThreaded.Mod_Patches
                 return MapComp_Drought.ContainsKey(m);
             }
         }
+        public static bool ContainsKey2(Dictionary<Plant, bool> affectedPlants, Plant p)
+        {
+            lock (affectedPlants)
+            {
+                return affectedPlants.ContainsKey(p);
+            }
+        }
+        public static void SetOrAdd(Dictionary<Plant, bool> affectedPlants, Plant p, bool b)//extension method
+        {
+            lock (affectedPlants)
+            {
+                affectedPlants[p] = b;
+            }
+        }
         public static void Add(Dictionary<Map, object> MapComp_Drought, Map m, object j)
         {
             lock (MapComp_Drought)
@@ -50,17 +72,22 @@ namespace RimThreaded.Mod_Patches
                 MapComp_Drought[m] = j;
             }
         }
-        public static bool TryGetValue(Dictionary<Map, object> MapComp_Drought, Map m, out object j)
+        public static object TryGetValue(Dictionary<Map, object> MapComp_Drought, Map m, object o = null)//extension method
         {
             lock (MapComp_Drought)
             {
-                return MapComp_Drought.TryGetValue(m, out j);
+                if (MapComp_Drought.ContainsKey(m))
+                {
+                    return MapComp_Drought[m];
+                }
+                return o;
             }
         }
-
         public static IEnumerable<CodeInstruction> Postfix(IEnumerable<CodeInstruction> instructions, ILGenerator iLGenerator)
         {
             Type MapComp_Drought = typeof(Dictionary<,>).MakeGenericType(new[] { typeof(Map), TypeByName("VEE.MapComp_Drought") });
+            Type affectedPlants = typeof(Dictionary<Plant, bool>);
+            Type GenCollection = typeof(Verse.GenCollection);// You need to refer the extension class
             foreach (CodeInstruction i in instructions)
             {
                 if (i.opcode == OpCodes.Callvirt || i.opcode == OpCodes.Call)
@@ -69,13 +96,44 @@ namespace RimThreaded.Mod_Patches
                     {
                         i.operand = Method(typeof(VEE_Patch), nameof(ContainsKey));
                     }
+                    if ((MethodInfo)i.operand == Method(affectedPlants, "ContainsKey"))
+                    {
+                        i.operand = Method(typeof(VEE_Patch), nameof(ContainsKey2));
+                    }
+                    if ((MethodInfo)i.operand == Method(GenCollection, "SetOrAdd", null, new Type[] {typeof(Plant), typeof(bool) }))
+                    {
+                        i.operand = Method(typeof(VEE_Patch), nameof(SetOrAdd));
+                    }
                     if ((MethodInfo)i.operand == Method(MapComp_Drought, "Add"))
                     {
                         i.operand = Method(typeof(VEE_Patch), nameof(Add));
                     }
-                    if ((MethodInfo)i.operand == Method(MapComp_Drought, "TryGetValue"))
+                    if ((MethodInfo)i.operand == Method(GenCollection, "TryGetValue", null, new Type[] {typeof(Map), TypeByName("VEE.MapComp_Drought") }))
                     {
                         i.operand = Method(typeof(VEE_Patch), nameof(TryGetValue));
+                    }
+                }
+                yield return i;
+            }
+        }
+
+        public static void Clear(Dictionary<Plant, bool> affectedPlants)
+        {
+            lock (affectedPlants)
+            {
+                affectedPlants.Clear();
+            }
+        }
+        public static IEnumerable<CodeInstruction> MapComponentTick(IEnumerable<CodeInstruction> instructions, ILGenerator iLGenerator)
+        {
+            Type affectedPlants = typeof(Dictionary<Plant, bool>);
+            foreach (CodeInstruction i in instructions)
+            {
+                if (i.opcode == OpCodes.Callvirt)
+                {
+                    if ((MethodInfo)i.operand == Method(affectedPlants, "Clear"))
+                    {
+                        i.operand = Method(typeof(VEE_Patch), nameof(Clear));
                     }
                 }
                 yield return i;

--- a/Source/ReservationManager_Patch.cs
+++ b/Source/ReservationManager_Patch.cs
@@ -17,6 +17,9 @@ namespace RimThreaded
 		public static readonly Dictionary<ReservationManager, Dictionary<Pawn, List<Reservation>>> reservationClaimantDicts =
 			new Dictionary<ReservationManager, Dictionary<Pawn, List<Reservation>>>();
 
+		[ThreadStatic] static public List<Reservation> newReservationClaimantList;
+		[ThreadStatic] static public List<Reservation> newReservationTargetList;
+
 		internal static void RunDestructivePatches()
 		{
 			Type original = typeof(ReservationManager);
@@ -40,6 +43,11 @@ namespace RimThreaded
 
 			//RimThreadedHarmony.Postfix(original, patched, "Release", "PostRelease");
 			//RimThreadedHarmony.Postfix(original, patched, "Release", "PostReleaseAllForTarget");
+		}
+		internal static void InitializeThreadStatics()
+		{
+			newReservationClaimantList = new List<Reservation>();
+			newReservationTargetList = new List<Reservation>();
 		}
 
 		public static bool ExposeData(ReservationManager __instance)
@@ -512,8 +520,16 @@ namespace RimThreaded
 				{
 					if (job.playerForced && __instance.CanReserve(claimant, target, maxPawns, stackCount, layer, true))
 					{
-						reservation = new Reservation(claimant, job, maxPawns, stackCount, target, layer);
-                        List<Reservation> claimantReservations;
+						//reservation = new Reservation(claimant, job, maxPawns, stackCount, target, layer);
+						reservation = SimplePool_Patch<Reservation>.Get();
+						reservation.claimant = claimant;
+						reservation.job = job;
+						reservation.maxPawns = maxPawns;
+						reservation.stackCount = stackCount;
+						reservation.target = target;
+						reservation.layer = layer;
+
+						List<Reservation> claimantReservations;
 						
 						reservationTargetDict = getReservationTargetDict(__instance);
 						//newReservationTargetList = new List<Reservation>(getReservationTargetList(reservationTargetDict, target))
@@ -557,7 +573,14 @@ namespace RimThreaded
 					__result = false;
 					return false;
 				}
-				reservation = new Reservation(claimant, job, maxPawns, stackCount, target, layer);
+				//reservation = new Reservation(claimant, job, maxPawns, stackCount, target, layer);
+				reservation = SimplePool_Patch<Reservation>.Get();
+				reservation.claimant = claimant;
+				reservation.job = job;
+				reservation.maxPawns = maxPawns;
+				reservation.stackCount = stackCount;
+				reservation.target = target;
+				reservation.layer = layer;
 
                 reservationTargetDict = getReservationTargetDict(__instance);
 				//newReservationTargetList = new List<Reservation>(getReservationTargetList(reservationTargetDict, target))
@@ -587,7 +610,7 @@ namespace RimThreaded
 			List<Reservation> reservationTargetListUnsafe = getReservationTargetList(__instance, target);
 			foreach (Reservation reservation2 in reservationTargetListUnsafe) 
 			{ 
-				if (reservation2.Claimant == claimant && reservation2.Job == job)
+				if (reservation2.Claimant == claimant && reservation2.Job == job)//because of the Simple_Pool this check might require to be inside the lock. Is not causing problems now but is doubtful.
 				{
 					reservation1 = reservation2;
 					break;
@@ -601,18 +624,23 @@ namespace RimThreaded
 				{
 					Dictionary<Pawn, List<Reservation>> reservationClaimantDict = getReservationClaimantDict(__instance);
 					List<Reservation> reservationClaimantList = getReservationClaimantList(reservationClaimantDict, claimant);
-					List<Reservation> newReservationClaimantList = new List<Reservation>();
+					//List<Reservation> newReservationClaimantList = new List<Reservation>();
+
+					newReservationClaimantList.Clear();
 					foreach (Reservation reservation in reservationClaimantList)
 					{
 						if (reservation != reservation1)
 						{
 							newReservationClaimantList.Add(reservation);
 						}
-						reservationClaimantDict[claimant] = newReservationClaimantList;
+						//reservationClaimantDict[claimant] = newReservationClaimantList;//why inside the foreach?
 					}
+					reservationClaimantDict[claimant].Clear();
+					reservationClaimantDict[claimant].AddRange(newReservationClaimantList);
 					Dictionary<LocalTargetInfo, List<Reservation>> reservationTargetDict = getReservationTargetDict(__instance);
 					List<Reservation> reservationTargetList = getReservationTargetList(reservationTargetDict, target);
-					List<Reservation> newReservationTargetList = new List<Reservation>();
+					//List<Reservation> newReservationTargetList = new List<Reservation>();
+					newReservationTargetList.Clear();
 					foreach (Reservation reservation2 in reservationTargetList)
 					{
 						if (reservation2 != reservation1)
@@ -620,7 +648,10 @@ namespace RimThreaded
 							newReservationTargetList.Add(reservation2);
 						}
 					}
-					reservationTargetDict[target] = newReservationTargetList;					
+					SimplePool_Patch<Reservation>.Return(reservation1);
+					//reservationTargetDict[target] = newReservationTargetList;	
+					reservationTargetDict[target].Clear();
+					reservationTargetDict[target].AddRange(newReservationTargetList);
 				}
 			}
 
@@ -646,8 +677,9 @@ namespace RimThreaded
 			Dictionary<LocalTargetInfo, List<Reservation>> reservationTargetDict = getReservationTargetDict(__instance);
 			lock (__instance)
 			{
-				List<Reservation> reservationTargetList = getReservationTargetList(reservationTargetDict, t.Position);
-				List<Reservation> newReservationTargetList = new List<Reservation>();
+				List<Reservation> reservationTargetList = getReservationTargetList(reservationTargetDict, t.Position);//t.Position? Or just t?
+				//List<Reservation> newReservationTargetList = new List<Reservation>();
+				newReservationTargetList.Clear();
 				foreach (Reservation reservation in reservationTargetList)
 				{
 					LocalTargetInfo target = reservation.Target;
@@ -660,7 +692,9 @@ namespace RimThreaded
 					{
 						Dictionary<Pawn, List<Reservation>> reservationClaimantDict = getReservationClaimantDict(__instance);
 						List<Reservation> reservationClaimantList = getReservationClaimantList(reservationClaimantDict, reservation.Claimant);
-						List<Reservation> newReservationClaimantList = new List<Reservation>();
+						//List<Reservation> newReservationClaimantList = new List<Reservation>();
+
+						newReservationClaimantList.Clear();
 						foreach (Reservation reservation2 in reservationClaimantList)
 						{
 							if (reservation2.Target.Thing != t)
@@ -668,7 +702,11 @@ namespace RimThreaded
 								newReservationClaimantList.Add(reservation2);
 							}
 						}
-						reservationClaimantDict[reservation.Claimant] = newReservationTargetList;
+						//reservationClaimantDict[reservation.Claimant] = newReservationTargetList;//  ???
+						reservationClaimantDict[reservation.Claimant].Clear();
+						reservationClaimantDict[reservation.Claimant].AddRange(newReservationClaimantList);
+
+						SimplePool_Patch<Reservation>.Return(reservation);
 
 						//HaulingCache
 						if (thing != null && thing.def.EverHaulable)
@@ -681,7 +719,9 @@ namespace RimThreaded
 						}
 
 					}
-					reservationTargetDict[t.Position] = newReservationTargetList;
+					//reservationTargetDict[t.Position] = newReservationTargetList;
+					reservationTargetDict[t.Position].Clear();
+					reservationTargetDict[t.Position].AddRange(newReservationTargetList);
 				}
 			
 			}
@@ -694,7 +734,9 @@ namespace RimThreaded
 			{
 				Dictionary<LocalTargetInfo, List<Reservation>> reservationTargetDict = getReservationTargetDict(__instance);
 				List<Reservation> reservationClaimantList = getReservationClaimantList(reservationClaimantDict, claimant);
-				List<Reservation> newReservationClaimantList = new List<Reservation>();
+				//List<Reservation> newReservationClaimantList = new List<Reservation>();
+
+				newReservationClaimantList.Clear();
 				foreach (Reservation reservation in reservationClaimantList)
 				{
 					if (reservation.Job != job)
@@ -705,8 +747,11 @@ namespace RimThreaded
 					{
                         LocalTargetInfo target = reservation.Target;
 						List<Reservation> reservationTargetList = getReservationTargetList(reservationTargetDict, target);
-						List<Reservation> newReservationTargetList = new List<Reservation>();
-                        for (int index = 0; index < reservationTargetList.Count; index++)
+						//List<Reservation> newReservationTargetList = new List<Reservation>();
+
+						newReservationTargetList.Clear();
+
+						for (int index = 0; index < reservationTargetList.Count; index++)
                         {
                             Reservation reservation2 = reservationTargetList[index];
                             if (reservation2.Claimant != claimant || reservation2.Job != job)
@@ -715,7 +760,12 @@ namespace RimThreaded
                             }
                         }
 
-                        reservationTargetDict[target] = newReservationTargetList;
+						//reservationTargetDict[target] = newReservationTargetList;
+						reservationTargetDict[target].Clear();
+						reservationTargetDict[target].AddRange(newReservationTargetList);
+
+						SimplePool_Patch<Reservation>.Return(reservation);
+
 						//HaulingCache
 						Thing thing = target.Thing;
 						if (thing != null && thing.def.EverHaulable)
@@ -728,8 +778,10 @@ namespace RimThreaded
 						}
 
 					}
-					reservationClaimantDict[claimant] = newReservationClaimantList;
+					//reservationClaimantDict[claimant] = newReservationClaimantList;
 				}
+				reservationClaimantDict[claimant].Clear();
+				reservationClaimantDict[claimant].AddRange(newReservationClaimantList);
 			}
 			return false;
 		}
@@ -745,8 +797,11 @@ namespace RimThreaded
 				{
 					LocalTargetInfo target = reservation.Target;
 					List<Reservation> reservationTargetList = getReservationTargetList(reservationTargetDict, target);
-					List<Reservation> newReservationTargetList = new List<Reservation>();
-                    for (int index = 0; index < reservationTargetList.Count; index++)
+					//List<Reservation> newReservationTargetList = new List<Reservation>();
+
+					newReservationTargetList.Clear();
+
+					for (int index = 0; index < reservationTargetList.Count; index++)
                     {
                         Reservation reservation2 = reservationTargetList[index];
                         if (reservation2.Claimant != claimant)
@@ -755,7 +810,10 @@ namespace RimThreaded
                         }
                     }
 
-                    reservationTargetDict[target] = newReservationTargetList;
+					SimplePool_Patch<Reservation>.Return(reservation);
+					//reservationTargetDict[target] = newReservationTargetList;
+					reservationTargetDict[target].Clear();
+					reservationTargetDict[target].AddRange(newReservationTargetList);
 					//HaulingCache
 					Thing thing = target.Thing;
 					if (thing != null && thing.def.EverHaulable)
@@ -768,7 +826,8 @@ namespace RimThreaded
 					}
 
 				}
-				reservationClaimantDict[claimant] = new List<Reservation>();
+				//reservationClaimantDict[claimant] = new List<Reservation>();
+				reservationClaimantDict[claimant].Clear();
 			}
 			return false;
 		}

--- a/Source/ReservationManager_Patch.cs
+++ b/Source/ReservationManager_Patch.cs
@@ -719,11 +719,11 @@ namespace RimThreaded
 						}
 
 					}
-					//reservationTargetDict[t.Position] = newReservationTargetList;
-					reservationTargetDict[t.Position].Clear();
-					reservationTargetDict[t.Position].AddRange(newReservationTargetList);
+					//reservationTargetDict[t.Position] = newReservationTargetList; //??? why inside the foreach?
 				}
-			
+				reservationTargetDict[t.Position].Clear();
+				reservationTargetDict[t.Position].AddRange(newReservationTargetList);
+
 			}
 			return false;
 		}

--- a/Source/RimThreaded.cs
+++ b/Source/RimThreaded.cs
@@ -219,7 +219,7 @@ namespace RimThreaded
             World_Patch.InitializeThreadStatics();
             WorldPawns_Patch.InitializeThreadStatics();
             AttackTargetReservationManager_Patch.InitializeThreadStatics();
-            //ReservationManager_Patch.InitializeThreadStatics();
+            ReservationManager_Patch.InitializeThreadStatics();
         }
         private static void ProcessTicks(ThreadInfo threadInfo)
         {
@@ -391,6 +391,7 @@ namespace RimThreaded
                     tickList.threadCount = -1;
                 }
                 //OneTickPools Ticks go here.
+
                 listsFullyProcessed = 0;
                 workingOnDateNotifierTick = -1;
                 workingOnWorldTick = -1;

--- a/Source/RimThreadedHarmony.cs
+++ b/Source/RimThreadedHarmony.cs
@@ -984,6 +984,7 @@ namespace RimThreaded
 			PawnRules_Patch.Patch();
 			ZombieLand_Patch.Patch();
 			VEE_Patch.Patch();
+			SOS2_Patch.Patch();
 			//SpeakUp_Patch.Patch();
 			RimWar_Patch.Patch();
 		}

--- a/Source/Room_Patch.cs
+++ b/Source/Room_Patch.cs
@@ -26,7 +26,25 @@ namespace RimThreaded
 #endif
 			RimThreadedHarmony.Prefix(original, patched, nameof(Notify_RoofChanged));
 			RimThreadedHarmony.Prefix(original, patched, nameof(UpdateRoomStatsAndRole));
+
+			RimThreadedHarmony.Prefix(original, patched, nameof(get_Fogged));
 		}
+
+		public static bool get_Fogged(Room __instance, ref bool __result)
+		{
+			__result = false;
+            if (__instance == null || __instance.RegionCount == 0)
+            {
+                return false;
+            }
+            if (__instance.Map == null || __instance.FirstRegion == null || __instance.FirstRegion.Cells.First() == null)
+            {
+                return false;
+            }
+            __result = __instance.FirstRegion.Cells.First().Fogged(__instance.Map);//unbelievable this works and the vanilla FirstRegion.AnyCell.Fogged(Map) doesn't.
+			return false;
+		}
+#if RW12
 		public static bool Notify_ContainedThingSpawnedOrDespawned(Room __instance, Thing th)
 		{
 			if (th.def.category == ThingCategory.Mote || th.def.category == ThingCategory.Projectile || th.def.category == ThingCategory.Ethereal || th.def.category == ThingCategory.Pawn)
@@ -52,7 +70,6 @@ namespace RimThreaded
 			__instance.statsAndRoleDirty = true;
 			return false;
 		}
-#if RW12
 		public static bool OpenRoofCountStopAt(Room __instance, ref int __result, int threshold)
 		{
 			//IEnumerator<IntVec3> cachedOpenRoofState2 = __instance.Cells.GetEnumerator();

--- a/Source/SimplePool_Patch.cs
+++ b/Source/SimplePool_Patch.cs
@@ -10,6 +10,6 @@ namespace RimThreaded
 
         public static T Get() => FreeItems.TryPop(out T freeItem) ? freeItem : new T();
 
-        public static void Return(T item) => FreeItems.Push(item);
+        public static void Return(T item) => FreeItems.Push(item);//as a precaution this might require a check for duplicates.
     }
 }


### PR DESCRIPTION
-Rebuilt Reservation Manager:
-Fixed an inconsistency with the previous iteration of the ReservationManager where ReleaseAllForTarget was setting reservationClaimantDict to an inconsistent state.
-The Reservation Manager now completly recycle the memory.
-Added Compatibility with SOS2 Vacuum Check.
-Fixed an unbelievable race con in Room.Fogged that can only be
appreciated when executing certain very GenSpawn.Spawn intensive methods like SOS2 GenerateShip (expecially when generating tons of beds) (Not yet completly fixed but less noticeable).
-Updated VEE compat.
-Updated SOS2 compat.