### PR TITLE
Fixes grammar ERRs in Speak Up!

### DIFF
--- a/Source/replacements_1.3.json
+++ b/Source/replacements_1.3.json
@@ -891,12 +891,6 @@
       "ClassName": "Verse.Grammar.GrammarResolver",
       "ThreadStatics": [
         {
-          "FieldName": "rules"
-        },
-        {
-          "FieldName": "rulePool"
-        },
-        {
           "FieldName": "loopCount"
         },
         {


### PR DESCRIPTION
This is probably not thread safe; I think we may need to synchronize calls to `GrammarResolver.Resolve()` so that `GrammarResolver.AddRule()`s are not interleaved with the `rules.Clear()` at the start of `ResolveUnsafe`.

![image](https://user-images.githubusercontent.com/990069/139610584-566b311b-4f31-48c2-8529-10ac92e65b06.png)
